### PR TITLE
chore: change build format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ yarn add microcms-js-sdk
 CDN support.
 
 ```
-<script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
+<script src="https://unpkg.com/microcms-js-sdk@latest/dist/microcms-js-sdk.umd.js"></script>
 ```
 
 ### How to use

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "microcms-js-sdk",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "microcms-js-sdk",
   "version": "1.2.0",
   "description": "JavaScript SDK Client for microCMS.",
-  "main": "./dist/cjs/microcms-js-sdk.js",
-  "module": "./dist/esm/microcms-js-sdk.js",
-  "unpkg": "./dist/umd/microcms-js-sdk.js",
-  "types": "./dist/cjs/index.d.ts",
+  "main": "./dist/microcms-js-sdk.js",
+  "module": "./dist/microcms-js-sdk.esm.js",
+  "unpkg": "./dist/microcms-js-sdk.umd.js",
+  "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/microcmsio/microcms-js-sdk.git"
@@ -14,9 +14,10 @@
   "license": "Apache-2.0",
   "keywords": ["JavaScript", "node", "SDK", "microCMS"],
   "scripts": {
-    "build": "rollup -c",
+    "build": "npm run clean && rollup -c",
     "lint": "eslint ./src",
-    "lint:fix": "eslint --fix ./src"
+    "lint:fix": "eslint --fix ./src",
+    "clean": "rimraf dist"
   },
   "files": ["dist"],
   "dependencies": {
@@ -41,6 +42,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-standard": "^5.0.0",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.47.0",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.30.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default [
     input: './src/index.ts',
     output: [
       {
-        file: `./dist/cjs/${pkg.name}.js`,
+        file: `./dist/${pkg.name}.js`,
         sourcemap: 'inline',
         format: 'cjs',
       },
@@ -29,7 +29,7 @@ export default [
     input: './src/index.ts',
     output: [
       {
-        file: `./dist/esm/${pkg.name}.js`,
+        file: `./dist/${pkg.name}.esm.js`,
         sourcemap: 'inline',
         format: 'esm',
       },
@@ -47,7 +47,7 @@ export default [
     input: './src/index.ts',
     output: [
       {
-        file: `./dist/umd/${pkg.name}.js`,
+        file: `./dist/${pkg.name}.umd.js`,
         format: 'umd',
         name: 'microcms',
       },


### PR DESCRIPTION
ビルド時に`ファイル名 + 各フォーマット.js `で出力するように変更しました。

## 変更点

- dist/cjs/microcms-js-sdk -> dist/microcms-js-sdk.js
- dist/esm/microcms-js-sdk -> dist/microcms-js-sdk.esm.js
- dist/umd/microcms-js-sdk -> dist/microcms-js-sdk.umd.js

## 影響

`unpkg`で参照しているumdファイルのパスが変わります。

```
<script src="https://unpkg.com/microcms-js-sdk@latest/dist/microcms-js-sdk.umd.js"></script>
```