### PR TITLE
Allow `queries.fields` to string array

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface QueriesType {
   limit?: number;
   offset?: number;
   orders?: string;
-  fields?: string;
+  fields?: string|string[];
   q?: string;
   depth?: depthNumber;
   ids?: string;

--- a/src/utils/parseQuery.ts
+++ b/src/utils/parseQuery.ts
@@ -12,7 +12,7 @@ export const parseQuery = (queries: QueriesType): string => {
   if (!isObject<QueriesType>(queries)) {
     throw new Error('queries is not object');
   }
-  const queryString = qs.stringify(queries);
+  const queryString = qs.stringify(queries, {arrayFormat: 'comma'});
 
   return queryString;
 };


### PR DESCRIPTION
- queriesをstringに変換しているメソッドに`{arrayFormat: 'comma'}`というオプションを追加。
https://github.com/ljharb/qs#:~:text=qs.stringify(%7B%20a%3A%20%5B%27b%27%2C%20%27c%27%5D%20%7D%2C%20%7B%20arrayFormat%3A%20%27comma%27%20%7D)
- **queries.fields**の型定義を`string|string[]`に変更しました。