### PR TITLE
型定義を関数の実態に合わせる

### DIFF
--- a/src/utils/isCheckValue.ts
+++ b/src/utils/isCheckValue.ts
@@ -1,19 +1,19 @@
 /**
  * Check object
  *
- * @param {object} value
- * @return {boolean}
+ * @param {unknown} value
+ * @returns {boolean}
  */
-export const isObject = <T>(value: T): boolean => {
+export const isObject = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === 'object';
 };
 
 /**
  * Check string
  *
- * @param {string} value
- * @return {boolean}
+ * @param {unknown} value
+ * @returns {boolean}
  */
-export const isString = (value: string): boolean => {
+export const isString = (value: unknown): value is string => {
   return value !== null && typeof value == 'string';
 };

--- a/src/utils/isCheckValue.ts
+++ b/src/utils/isCheckValue.ts
@@ -15,5 +15,5 @@ export const isObject = (value: unknown): value is Record<string, unknown> => {
  * @returns {boolean}
  */
 export const isString = (value: unknown): value is string => {
-  return value !== null && typeof value == 'string';
+  return typeof value === 'string';
 };

--- a/src/utils/parseQuery.ts
+++ b/src/utils/parseQuery.ts
@@ -9,10 +9,10 @@ import { isObject } from './isCheckValue';
 import { MicroCMSQueries } from '../types';
 
 export const parseQuery = (queries: MicroCMSQueries): string => {
-  if (!isObject<MicroCMSQueries>(queries)) {
+  if (!isObject(queries)) {
     throw new Error('queries is not object');
   }
-  const queryString = qs.stringify(queries, {arrayFormat: 'comma'});
+  const queryString = qs.stringify(queries, { arrayFormat: 'comma' });
 
   return queryString;
 };


### PR DESCRIPTION
## 概要

isCheckValueファイルの関数における型定義を実態に合わせる変更をしました。
また、`isString` 関数のチェックで、
nullじゃない判定
等価演算子を使った判定
がありましたので、適切な判定に修正しています。

## なぜ

1. `isString` は文字列しか受け取れず、型の判定をするということができない。（例えばテストを書く際に文字列以外を渡せない）
2. 返り値をisアサーションにすることで、実装上もその型ガードの後の記述では想定通りの型となる