### PR TITLE
Support WRITE API

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ client
       body: 'body',
     },
     // Available with microCMS paid plans
+    // https://microcms.io/pricing
     isDraft: true,
   })
   .then((res) => console.log(res.id))
@@ -154,6 +155,7 @@ client
       body: 'body',
     },
     // Available with microCMS paid plans
+    // https://microcms.io/pricing
     isDraft: true,
   })
   .then((res) => console.log(res.id))

--- a/README.md
+++ b/README.md
@@ -101,6 +101,94 @@ client
   .catch((err) => console.log(err));
 ```
 
+#### WRITE API
+
+The following is how to use the write system when making a request to the write system API.
+
+```javascript
+// Create content
+client
+  .create({
+    endpoint: 'endpoint',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+
+// Create content with specified ID
+client
+  .create({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+// Create draft content
+client
+  .create({
+    endpoint: 'endpoint',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+    isDraft: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+
+// Create draft content with specified ID
+client
+  .create({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+    isDraft: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+
+// Update content
+client
+  .update({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+    content: {
+      title: 'title',
+    },
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+
+// Update object form content
+client
+  .update({
+    endpoint: 'endpoint',
+    content: {
+      title: 'title',
+    },
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.log(err));
+
+// Delete content
+client
+  .delete({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+  })
+  .catch((err) => console.log(err));
+```
+
 ### TypeScript 
 
 If you are using TypeScript, use `getList`, `getListDetail`, `getObject`. This internally contains a common type of content.
@@ -146,6 +234,47 @@ client.getListDetail<Content>({ //other })
  * } 
  */
 client.getObject<Content>({ //other })
+```
+
+Write functions can also be performed type-safely.
+
+```typescript
+type Content = {
+  title: string
+  body?: string
+}
+
+client.create<Content>({
+  endpoint: 'endpoint',
+  // Since `content` will be of type `Content`, no required fields will be missed.
+  content: {
+    title: 'title',
+    body: 'body',
+  },
+})
+
+client.update<Content>({
+  endpoint: 'endpoint',
+  // The `content` will be of type `Partial<Content>`, so you can enter only the items needed for the update.
+  content: {
+    body: 'body',
+  },
+})
+```
+
+## Tips
+
+### Separate API keys for read and write
+
+```javascript
+const readClient = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'readApiKey',
+})
+const writeClient = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'writeApiKey',
+})
 ```
 
 # LICENSE

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ client
       title: 'title',
       body: 'body',
     },
+    // Available with microCMS paid plans
     isDraft: true,
   })
   .then((res) => console.log(res.id))
@@ -152,6 +153,7 @@ client
       title: 'title',
       body: 'body',
     },
+    // Available with microCMS paid plans
     isDraft: true,
   })
   .then((res) => console.log(res.id))

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -12,6 +12,8 @@ import {
   GetListRequest,
   GetListDetailRequest,
   GetObjectRequest,
+  WriteApiRequestResult,
+  CreateRequest,
   MicroCMSListResponse,
   MicroCMSListContent,
   MicroCMSObjectContent,
@@ -43,11 +45,14 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     contentId,
     queries = {},
     method,
+    customHeaders,
+    customBody,
   }: MakeRequest): Promise<T> => {
     const queryString = parseQuery(queries);
 
     const baseHeaders: RequestInit = {
-      headers: { 'X-MICROCMS-API-KEY': apiKey },
+      headers: { ...customHeaders, 'X-MICROCMS-API-KEY': apiKey },
+      body: customBody,
       method,
     };
 
@@ -142,8 +147,31 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
   /**
    * Create new content in the microCMS list API data
    */
-  const create = async () => {
-    return;
+  const create = async <T extends Record<string | number, any>>({
+    endpoint,
+    contentId,
+    content,
+    isDraft = false,
+  }: CreateRequest<T>): Promise<WriteApiRequestResult> => {
+    if (!endpoint) {
+      return Promise.reject(new Error('endpoint is required'));
+    }
+
+    const queries: MakeRequest['queries'] = isDraft ? { status: 'draft' } : {};
+    const method: MakeRequest['method'] = contentId ? 'PUT' : 'POST';
+    const customHeaders: MakeRequest['customHeaders'] = {
+      'Content-Type': 'application/json',
+    };
+    const customBody: MakeRequest['customBody'] = JSON.stringify(content);
+
+    return makeRequest({
+      endpoint,
+      contentId,
+      queries,
+      method,
+      customHeaders,
+      customBody,
+    });
   };
 
   /**

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -2,7 +2,7 @@
  * microCMS API SDK
  * https://github.com/microcmsio/microcms-js-sdk
  */
-import fetch from 'node-fetch';
+import fetch, { RequestInit } from 'node-fetch';
 import { parseQuery } from './utils/parseQuery';
 import { isString } from './utils/isCheckValue';
 import {
@@ -42,13 +42,14 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     endpoint,
     contentId,
     queries = {},
+    method,
   }: MakeRequest): Promise<T> => {
     const queryString = parseQuery(queries);
 
-    const baseHeaders = {
+    const baseHeaders: RequestInit = {
       headers: { 'X-MICROCMS-API-KEY': apiKey },
+      method,
     };
-
 
     const url = `${baseUrl}/${endpoint}${contentId ? `/${contentId}` : ''}${
       queryString ? `?${queryString}` : ''

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -17,6 +17,7 @@ import {
   MicroCMSListResponse,
   MicroCMSListContent,
   MicroCMSObjectContent,
+  UpdateRequest,
 } from './types';
 import { API_VERSION, BASE_DOMAIN } from './utils/constants';
 
@@ -177,8 +178,28 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
   /**
    * Update content in ther microCMS list and object API data
    */
-  const update = async () => {
-    return;
+  const update = async <T extends Record<string | number, any>>({
+    endpoint,
+    contentId,
+    content,
+  }: UpdateRequest<T>): Promise<WriteApiRequestResult> => {
+    if (!endpoint) {
+      return Promise.reject(new Error('endpoint is required'));
+    }
+
+    const method: MakeRequest['method'] = 'PATCH';
+    const customHeaders: MakeRequest['customHeaders'] = {
+      'Content-Type': 'application/json',
+    };
+    const customBody: MakeRequest['customBody'] = JSON.stringify(content);
+
+    return makeRequest({
+      endpoint,
+      contentId,
+      method,
+      customHeaders,
+      customBody,
+    });
   };
 
   /**

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -139,10 +139,34 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     });
   };
 
+  /**
+   * Create new content in the microCMS list API data
+   */
+  const create = async () => {
+    return;
+  };
+
+  /**
+   * Update content in ther microCMS list and object API data
+   */
+  const update = async () => {
+    return;
+  };
+
+  /**
+   * Delete content in ther microCMS list and object API data
+   */
+  const _delete = async () => {
+    return;
+  };
+
   return {
     get,
     getList,
     getListDetail,
     getObject,
+    create,
+    update,
+    delete: _delete,
   };
 };

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -18,6 +18,7 @@ import {
   MicroCMSListContent,
   MicroCMSObjectContent,
   UpdateRequest,
+  DeleteRequest,
 } from './types';
 import { API_VERSION, BASE_DOMAIN } from './utils/constants';
 
@@ -205,8 +206,21 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
   /**
    * Delete content in ther microCMS list and object API data
    */
-  const _delete = async () => {
-    return;
+  const _delete = async ({
+    endpoint,
+    contentId,
+  }: DeleteRequest): Promise<void> => {
+    if (!endpoint) {
+      return Promise.reject(new Error('endpoint is required'));
+    }
+
+    if (!contentId) {
+      return Promise.reject(new Error('contentId is required'));
+    }
+
+    const method: MakeRequest['method'] = 'DELETE';
+
+    await makeRequest({ endpoint, contentId, method });
   };
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,3 +121,8 @@ export interface UpdateRequest<T> {
   contentId?: string;
   content: Partial<T>;
 }
+
+export interface DeleteRequest {
+  endpoint: string;
+  contentId: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,3 +115,9 @@ export interface CreateRequest<T> {
   content: T;
   isDraft?: boolean;
 }
+
+export interface UpdateRequest<T> {
+  endpoint: string;
+  contentId?: string;
+  content: Partial<T>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { HeadersInit } from 'node-fetch';
+
 /**
  * microCMS createClient params
  */
@@ -75,8 +77,9 @@ export type MicroCMSObjectContent = MicroCMSDate;
 export interface MakeRequest {
   endpoint: string;
   contentId?: string;
-  queries?: MicroCMSQueries;
+  queries?: MicroCMSQueries & Record<string, any>;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  customHeaders?: HeadersInit;
 }
 
 export interface GetRequest {
@@ -99,4 +102,15 @@ export interface GetListRequest {
 export interface GetObjectRequest {
   endpoint: string;
   queries?: MicroCMSQueries;
+}
+
+export interface WriteApiRequestResult {
+  id: string;
+}
+
+export interface CreateRequest<T> {
+  endpoint: string;
+  contentId?: string;
+  content: T;
+  isDraft?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface MakeRequest {
   endpoint: string;
   contentId?: string;
   queries?: MicroCMSQueries;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 }
 
 export interface GetRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { HeadersInit } from 'node-fetch';
+import { BodyInit, HeadersInit } from 'node-fetch';
 
 /**
  * microCMS createClient params
@@ -80,6 +80,7 @@ export interface MakeRequest {
   queries?: MicroCMSQueries & Record<string, any>;
   method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   customHeaders?: HeadersInit;
+  customBody?: BodyInit;
 }
 
 export interface GetRequest {

--- a/tests/createClient.test.ts
+++ b/tests/createClient.test.ts
@@ -11,6 +11,9 @@ describe('createClient', () => {
     expect(typeof client.getList === 'function').toBe(true);
     expect(typeof client.getListDetail === 'function').toBe(true);
     expect(typeof client.getObject === 'function').toBe(true);
+    expect(typeof client.create === 'function').toBe(true);
+    expect(typeof client.update === 'function').toBe(true);
+    expect(typeof client.delete === 'function').toBe(true);
   });
 
   test('Throws an error if `serviceDomain` or `apiKey` is missing', () => {

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -24,6 +24,28 @@ export const handlers = [
       })
     );
   }),
+  rest.post(`${baseUrl}/list-type`, (_, res, ctx) => {
+    return res(ctx.json({ id: 'foo' }));
+  }),
+  rest.put(`${baseUrl}/list-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ massage: 'contentId is necessary.' })
+    );
+  }),
+  rest.patch(`${baseUrl}/list-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ massage: 'Content is not exists.' })
+    );
+  }),
+  rest.delete(`${baseUrl}/list-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({ massage: 'Content is not exists.' })
+    );
+  }),
+
   rest.get(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
     return res(
       ctx.json({
@@ -36,6 +58,19 @@ export const handlers = [
       })
     );
   }),
+  rest.post(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
+    return res(ctx.status(404));
+  }),
+  rest.put(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
+    return res(ctx.status(201), ctx.json({ id: 'foo' }));
+  }),
+  rest.patch(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json({ id: 'foo' }));
+  }),
+  rest.delete(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
+    return res(ctx.status(202));
+  }),
+
   rest.get(`${baseUrl}/object-type`, (_, res, ctx) => {
     return res(
       ctx.json({
@@ -45,6 +80,33 @@ export const handlers = [
         updatedAt: '2022-10-28T04:04:29.625Z',
         publishedAt: '2022-10-28T04:04:29.625Z',
         revisedAt: '2022-10-28T04:04:29.625Z',
+      })
+    );
+  }),
+  rest.post(`${baseUrl}/object-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        message: 'POST is forbidden.',
+      })
+    );
+  }),
+  rest.put(`${baseUrl}/object-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        message: 'PUT is forbidden.',
+      })
+    );
+  }),
+  rest.patch(`${baseUrl}/object-type`, (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json({ id: 'foo' }));
+  }),
+  rest.delete(`${baseUrl}/object-type`, (_, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        message: 'DELETE is forbidden.',
       })
     );
   }),

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -59,7 +59,7 @@ export const handlers = [
     );
   }),
   rest.post(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
-    return res(ctx.status(404));
+    return res(ctx.status(404), ctx.json({}));
   }),
   rest.put(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
     return res(ctx.status(201), ctx.json({ id: 'foo' }));
@@ -68,7 +68,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json({ id: 'foo' }));
   }),
   rest.delete(`${baseUrl}/list-type/foo`, (_, res, ctx) => {
-    return res(ctx.status(202));
+    return res(ctx.status(202), ctx.json({}));
   }),
 
   rest.get(`${baseUrl}/object-type`, (_, res, ctx) => {

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -1,10 +1,103 @@
-describe('create', () => {
-  test.todo('Content can be submitted without specifying an id');
-  test.todo('Draft content can be submitted by specifying an id');
-  test.todo('Content can be submitted by specifying an id');
-  test.todo('Draft content can be submitted by specifying an id');
+import { rest } from 'msw';
 
-  test.todo('Returns an error message if `endpoint` is not specified');
+import { createClient } from '../src/createClient';
+
+import { testBaseUrl } from './mocks/handlers';
+import { server } from './mocks/server';
+
+const client = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'apiKey',
+});
+
+interface ContentType {
+  title: string;
+  body?: string;
+}
+
+describe('create', () => {
+  const postApiMockFn = jest.fn();
+  const putApiMockFn = jest.fn();
+
+  beforeEach(() => {
+    server.use(
+      rest.post(`${testBaseUrl}/list-type`, (req, res, ctx) => {
+        const statusParams = req.url.searchParams.get('status');
+        postApiMockFn(statusParams);
+        return res(ctx.json({ id: 'foo' }));
+      }),
+      rest.put(`${testBaseUrl}/list-type/foo`, (req, res, ctx) => {
+        const statusParams = req.url.searchParams.get('status');
+        putApiMockFn(statusParams);
+        return res(ctx.status(201), ctx.json({ id: 'foo' }));
+      })
+    );
+  });
+
+  test('Content can be posted without specifying an id', async () => {
+    const data = await client.create<ContentType>({
+      endpoint: 'list-type',
+      content: {
+        title: 'title',
+        body: 'body',
+      },
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm POST api was called
+    expect(postApiMockFn).toHaveBeenCalledTimes(1);
+  });
+  test('Draft content can be posted by specifying an id', async () => {
+    const data = await client.create<ContentType>({
+      endpoint: 'list-type',
+      content: {
+        title: 'title',
+        body: 'body',
+      },
+      isDraft: true,
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm POST api was called
+    expect(postApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that status=draft is specified for the query string
+    expect(postApiMockFn).toHaveBeenCalledWith('draft');
+  });
+  test('Content can be posted by specifying an id', async () => {
+    const data = await client.create<ContentType>({
+      endpoint: 'list-type',
+      contentId: 'foo',
+      content: {
+        title: 'title',
+        body: 'body',
+      },
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm PUT api was called
+    expect(putApiMockFn).toHaveBeenCalledTimes(1);
+  });
+  test('Draft content can be posted by specifying an id', async () => {
+    const data = await client.create<ContentType>({
+      endpoint: 'list-type',
+      contentId: 'foo',
+      content: {
+        title: 'title',
+        body: 'body',
+      },
+      isDraft: true,
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm PUT api was called
+    expect(putApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that status=draft is specified for the query string
+    expect(putApiMockFn).toHaveBeenCalledWith('draft');
+  });
+
+  test('Returns an error message if `endpoint` is not specified', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(client.create({})).rejects.toThrow(
+      new Error('endpoint is required')
+    );
+  });
 });
 describe('update', () => {
   test.todo('List format content can be updated');

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -187,8 +187,37 @@ describe('update', () => {
 });
 
 describe('delete', () => {
-  test.todo('List format content can be deleted');
+  const deleteApiMockFn = jest.fn();
 
-  test.todo('Returns an error message if `endpoint` is not specified');
-  test.todo('Returns an error message if `contentId` is not specified');
+  beforeEach(() => {
+    server.use(
+      rest.delete(`${testBaseUrl}/list-type/foo`, (_, res, ctx) => {
+        deleteApiMockFn();
+        return res(ctx.status(202), ctx.json({}));
+      })
+    );
+  });
+  afterEach(() => {
+    deleteApiMockFn.mockClear();
+  });
+
+  test('List format content can be deleted', async () => {
+    await client.delete({ endpoint: 'list-type', contentId: 'foo' });
+    expect(deleteApiMockFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('Returns an error message if `endpoint` is not specified', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(client.delete({})).rejects.toThrow(
+      new Error('endpoint is required')
+    );
+  });
+  test('Returns an error message if `contentId` is not specified', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(client.delete({ endpoint: 'list-type' })).rejects.toThrow(
+      new Error('contentId is required')
+    );
+  });
 });

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -21,14 +21,16 @@ describe('create', () => {
 
   beforeEach(() => {
     server.use(
-      rest.post(`${testBaseUrl}/list-type`, (req, res, ctx) => {
+      rest.post(`${testBaseUrl}/list-type`, async (req, res, ctx) => {
         const statusParams = req.url.searchParams.get('status');
-        postApiMockFn(statusParams);
+        const body = await req.json();
+        postApiMockFn(statusParams, body);
         return res(ctx.json({ id: 'foo' }));
       }),
-      rest.put(`${testBaseUrl}/list-type/foo`, (req, res, ctx) => {
+      rest.put(`${testBaseUrl}/list-type/foo`, async (req, res, ctx) => {
         const statusParams = req.url.searchParams.get('status');
-        putApiMockFn(statusParams);
+        const body = await req.json();
+        putApiMockFn(statusParams, body);
         return res(ctx.status(201), ctx.json({ id: 'foo' }));
       })
     );
@@ -49,6 +51,11 @@ describe('create', () => {
     expect(data).toEqual({ id: 'foo' });
     // Confirm POST api was called
     expect(postApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that body is specified.
+    expect(postApiMockFn).toHaveBeenCalledWith(null, {
+      title: 'title',
+      body: 'body',
+    });
   });
   test('Draft content can be posted by specifying an id', async () => {
     const data = await client.create<ContentType>({
@@ -62,8 +69,11 @@ describe('create', () => {
     expect(data).toEqual({ id: 'foo' });
     // Confirm POST api was called
     expect(postApiMockFn).toHaveBeenCalledTimes(1);
-    // Confirm that status=draft is specified for the query string
-    expect(postApiMockFn).toHaveBeenCalledWith('draft');
+    // Confirm that status=draft is specified in the query string and that body is specified.
+    expect(postApiMockFn).toHaveBeenCalledWith('draft', {
+      title: 'title',
+      body: 'body',
+    });
   });
   test('Content can be posted by specifying an id', async () => {
     const data = await client.create<ContentType>({
@@ -77,6 +87,11 @@ describe('create', () => {
     expect(data).toEqual({ id: 'foo' });
     // Confirm PUT api was called
     expect(putApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that body is specified.
+    expect(putApiMockFn).toHaveBeenCalledWith(null, {
+      title: 'title',
+      body: 'body',
+    });
   });
   test('Draft content can be posted by specifying an id', async () => {
     const data = await client.create<ContentType>({
@@ -91,8 +106,11 @@ describe('create', () => {
     expect(data).toEqual({ id: 'foo' });
     // Confirm PUT api was called
     expect(putApiMockFn).toHaveBeenCalledTimes(1);
-    // Confirm that status=draft is specified for the query string
-    expect(putApiMockFn).toHaveBeenCalledWith('draft');
+    // Confirm that status=draft is specified in the query string and that body is specified.
+    expect(putApiMockFn).toHaveBeenCalledWith('draft', {
+      title: 'title',
+      body: 'body',
+    });
   });
 
   test('Returns an error message if `endpoint` is not specified', () => {

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -1,6 +1,8 @@
 describe('create', () => {
-  test.todo('List format content can be posted');
-  test.todo('Object type content can be posted');
+  test.todo('Content can be submitted without specifying an id');
+  test.todo('Draft content can be submitted by specifying an id');
+  test.todo('Content can be submitted by specifying an id');
+  test.todo('Draft content can be submitted by specifying an id');
 
   test.todo('Returns an error message if `endpoint` is not specified');
 });

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -123,10 +123,67 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test.todo('List format content can be updated');
-  test.todo('Object type content can be updated');
+  const patchListApiMockFn = jest.fn();
+  const patchObjectApiMockFn = jest.fn();
 
-  test.todo('Returns an error message if `endpoint` is not specified');
+  beforeEach(() => {
+    server.use(
+      rest.patch(`${testBaseUrl}/list-type/foo`, async (req, res, ctx) => {
+        const body = await req.json();
+        patchListApiMockFn(body);
+        return res(ctx.status(200), ctx.json({ id: 'foo' }));
+      }),
+      rest.patch(`${testBaseUrl}/object-type`, async (req, res, ctx) => {
+        const body = await req.json();
+        patchObjectApiMockFn(body);
+        return res(ctx.status(200), ctx.json({ id: 'foo' }));
+      })
+    );
+  });
+  afterEach(() => {
+    patchListApiMockFn.mockClear();
+    patchObjectApiMockFn.mockClear();
+  });
+
+  test('List format content can be updated', async () => {
+    const data = await client.update<ContentType>({
+      endpoint: 'list-type',
+      contentId: 'foo',
+      content: {
+        title: 'title',
+      },
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm PUT api was called
+    expect(patchListApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that body is specified.
+    expect(patchListApiMockFn).toHaveBeenCalledWith({
+      title: 'title',
+    });
+  });
+  test('Object type content can be updated', async () => {
+    const data = await client.update<ContentType>({
+      endpoint: 'object-type',
+      content: {
+        title: 'title',
+      },
+    });
+    expect(data).toEqual({ id: 'foo' });
+    // Confirm PUT api was called
+    expect(patchObjectApiMockFn).toHaveBeenCalledTimes(1);
+    // Confirm that body is specified.
+    expect(patchObjectApiMockFn).toHaveBeenCalledWith({
+      title: 'title',
+    });
+  });
+
+  test('Returns an error message if `endpoint` is not specified', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(client.update({})).rejects.toThrow(
+      new Error('endpoint is required')
+    );
+  });
 });
 
 describe('delete', () => {

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -1,0 +1,18 @@
+describe('create', () => {
+  test.todo('List format content can be posted');
+  test.todo('Object type content can be posted');
+
+  test.todo('Returns an error message if `endpoint` is not specified');
+});
+describe('update', () => {
+  test.todo('List format content can be updated');
+  test.todo('Object type content can be updated');
+
+  test.todo('Returns an error message if `endpoint` is not specified');
+});
+describe('delete', () => {
+  test.todo('List format content can be deleted');
+
+  test.todo('Returns an error message if `endpoint` is not specified');
+  test.todo('Returns an error message if `contentId` is not specified');
+});

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -33,6 +33,10 @@ describe('create', () => {
       })
     );
   });
+  afterEach(() => {
+    postApiMockFn.mockClear();
+    putApiMockFn.mockClear();
+  });
 
   test('Content can be posted without specifying an id', async () => {
     const data = await client.create<ContentType>({
@@ -99,12 +103,14 @@ describe('create', () => {
     );
   });
 });
+
 describe('update', () => {
   test.todo('List format content can be updated');
   test.todo('Object type content can be updated');
 
   test.todo('Returns an error message if `endpoint` is not specified');
 });
+
 describe('delete', () => {
   test.todo('List format content can be deleted');
 


### PR DESCRIPTION
## 概要

WRITE APIに対応した関数を追加しました。

## テスト方法

### create

- contentIdが指定されたパターンとそうでないパターンでそれぞれPOST, PUT APIが呼ばれたことを確認
- status=draftが指定できることを確認
- bodyが指定されたことを確認

### update

- リスト形式とオブジェクト形式のAPIが呼ばれたことを確認
- bodyが指定されたことを確認

### delete

- DELETE APIが呼ばれたことを確認
- contentIdが指定されていないときにエラーを返すことを確認