### PR TITLE
delete apiはjsonを返さないのでそのように変更

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -42,14 +42,14 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
   /**
    * Make request
    */
-  const makeRequest = async <T>({
+  const makeRequest = async ({
     endpoint,
     contentId,
     queries = {},
     method,
     customHeaders,
     customBody,
-  }: MakeRequest): Promise<T> => {
+  }: MakeRequest) => {
     const queryString = parseQuery(queries);
 
     const baseHeaders: RequestInit = {
@@ -68,6 +68,8 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
       if (!response.ok) {
         throw new Error(`fetch API response status: ${response.status}`);
       }
+
+      if (method === 'DELETE') return;
 
       return response.json();
     } catch (error) {
@@ -96,7 +98,7 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest<T>({ endpoint, contentId, queries });
+    return await makeRequest({ endpoint, contentId, queries });
   };
 
   /**
@@ -109,7 +111,7 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest<MicroCMSListResponse<T>>({ endpoint, queries });
+    return await makeRequest({ endpoint, queries });
   };
 
   /**
@@ -123,7 +125,7 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest<T & MicroCMSListContent>({
+    return await makeRequest({
       endpoint,
       contentId,
       queries,
@@ -140,7 +142,7 @@ export const createClient = ({ serviceDomain, apiKey }: MicroCMSClient) => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest<T & MicroCMSObjectContent>({
+    return await makeRequest({
       endpoint,
       queries,
     });

--- a/tests/write.test.ts
+++ b/tests/write.test.ts
@@ -193,7 +193,7 @@ describe('delete', () => {
     server.use(
       rest.delete(`${testBaseUrl}/list-type/foo`, (_, res, ctx) => {
         deleteApiMockFn();
-        return res(ctx.status(202), ctx.json({}));
+        return res(ctx.status(202));
       })
     );
   });


### PR DESCRIPTION
## 概要

DELETE APIにおいて返却される値は空であるところ、`response.json()`をしてしまっていたので
DELETEの場合は何も返さないように変更しました。

## 背景

delete関数を実行すると処理自体は完了するが、
node-fetchのInvalid JSONエラーが出る。

## 変更の種類

fix