### PR TITLE
エラーメッセージをわかりやすくする

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -70,6 +70,8 @@ export const createClient = ({
 
       if (!response.ok) {
         const message = await (async () => {
+          // Enclose `response.json()` in a try since it may throw an error
+          // Only return the `message` if there is a `message`
           try {
             const { message } = await response.json();
             return message ?? null;
@@ -98,7 +100,7 @@ export const createClient = ({
         throw error.response.data;
       }
 
-      return Promise.reject(new Error(`Network Error.\n Details: ${error}`));
+      return Promise.reject(new Error(`Network Error.\n  Details: ${error}`));
     }
   };
 

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -69,7 +69,21 @@ export const createClient = ({
       });
 
       if (!response.ok) {
-        throw new Error(`fetch API response status: ${response.status}`);
+        const message = await (async () => {
+          try {
+            const { message } = await response.json();
+            return message ?? null;
+          } catch (_) {
+            return null;
+          }
+        })();
+        return Promise.reject(
+          new Error(
+            `fetch API response status: ${response.status}${
+              message ? `\n  message is \`${message}\`` : ''
+            }`
+          )
+        );
       }
 
       if (method === 'DELETE') return;
@@ -84,9 +98,7 @@ export const createClient = ({
         throw error.response.data;
       }
 
-      return Promise.reject(
-        new Error(`serviceDomain or endpoint may be wrong.\n Details: ${error}`)
-      );
+      return Promise.reject(new Error(`Network Error.\n Details: ${error}`));
     }
   };
 

--- a/tests/get.test.ts
+++ b/tests/get.test.ts
@@ -68,7 +68,7 @@ describe('get', () => {
 
     expect(client.get({ endpoint: 'list-type' })).rejects.toThrow(
       new Error(
-        'serviceDomain or endpoint may be wrong.\n Details: Error: fetch API response status: 500'
+        'fetch API response status: 500\n  message is `Internal Server Error`'
       )
     );
   });


### PR DESCRIPTION
`response.ok`が`false`の時にthrowされることによって、catch節に移動してしまい、
全て同じエラー内容が返されていましたのでそれを修正しました。
また、現状の実装ならcatch節に入るのはfetchでネットワークエラーになった場合のみなので、
そのようにエラーメッセージを修正しています。

<img width="508" alt="スクリーンショット 2022-11-09 18 07 39" src="https://user-images.githubusercontent.com/48201151/200787889-b9a5b1ce-29fe-46fe-8459-25ab790be2e3.png">
