### PR TITLE
richEditorFormatオプションをMicroCMSQueriesに追加

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface MicroCMSQueries {
   depth?: depthNumber;
   ids?: string | string[];
   filters?: string;
+  richEditorFormat?: 'html'|'object';
 }
 
 /**


### PR DESCRIPTION
Fixed #44 .

**Document**: https://document.microcms.io/content-api/get-content#hefb095db2a

## Did
- `type MicroCMSQueries`に項目を追加。