### PR TITLE
sesparate WRITE API examples on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ yarn add microcms-js-sdk
 
 CDN support.
 
-```
+```html
 <script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
 ```
 
@@ -104,7 +104,7 @@ client
   .catch((err) => console.error(err));
 ```
 
-#### WRITE API
+#### CREATE API
 
 The following is how to use the write system when making a request to the write system API.
 
@@ -163,7 +163,11 @@ client
   })
   .then((res) => console.log(res.id))
   .catch((err) => console.error(err));
+```
 
+### UPDATE API
+
+```javascript
 // Update content
 client
   .update({
@@ -186,7 +190,11 @@ client
   })
   .then((res) => console.log(res.id))
   .catch((err) => console.error(err));
+```
 
+### DELETE API
+
+```javascript
 // Delete content
 client
   .delete({


### PR DESCRIPTION
WRITE API のセクションでは、 create / update / delete が含まれています。
公式のコードとして、参考のリンクを貼りたいのですが、現在 write しかないので、それぞれの関数にリンク遷移できるようにしたいです。