### PR TITLE
各リクエストで fetch の requestInit をカスタマイズできるようにする

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -149,11 +149,17 @@ export const createClient = ({
     endpoint,
     contentId,
     queries = {},
+    customRequestInit,
   }: GetRequest): Promise<T> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest({ endpoint, contentId, queries });
+    return await makeRequest({
+      endpoint,
+      contentId,
+      queries,
+      requestInit: customRequestInit,
+    });
   };
 
   /**
@@ -162,11 +168,16 @@ export const createClient = ({
   const getList = async <T = any>({
     endpoint,
     queries = {},
+    customRequestInit,
   }: GetListRequest): Promise<MicroCMSListResponse<T>> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
-    return await makeRequest({ endpoint, queries });
+    return await makeRequest({
+      endpoint,
+      queries,
+      requestInit: customRequestInit,
+    });
   };
 
   /**
@@ -176,6 +187,7 @@ export const createClient = ({
     endpoint,
     contentId,
     queries = {},
+    customRequestInit,
   }: GetListDetailRequest): Promise<T & MicroCMSListContent> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
@@ -184,6 +196,7 @@ export const createClient = ({
       endpoint,
       contentId,
       queries,
+      requestInit: customRequestInit,
     });
   };
 
@@ -193,6 +206,7 @@ export const createClient = ({
   const getObject = async <T = any>({
     endpoint,
     queries = {},
+    customRequestInit,
   }: GetObjectRequest): Promise<T & MicroCMSObjectContent> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
@@ -200,6 +214,7 @@ export const createClient = ({
     return await makeRequest({
       endpoint,
       queries,
+      requestInit: customRequestInit,
     });
   };
 
@@ -211,6 +226,7 @@ export const createClient = ({
     contentId,
     content,
     isDraft = false,
+    customRequestInit,
   }: CreateRequest<T>): Promise<WriteApiRequestResult> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
@@ -223,6 +239,7 @@ export const createClient = ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(content),
+      ...customRequestInit,
     };
 
     return makeRequest({
@@ -240,6 +257,7 @@ export const createClient = ({
     endpoint,
     contentId,
     content,
+    customRequestInit,
   }: UpdateRequest<T>): Promise<WriteApiRequestResult> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
@@ -251,6 +269,7 @@ export const createClient = ({
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(content),
+      ...customRequestInit,
     };
 
     return makeRequest({
@@ -266,6 +285,7 @@ export const createClient = ({
   const _delete = async ({
     endpoint,
     contentId,
+    customRequestInit,
   }: DeleteRequest): Promise<void> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
@@ -277,6 +297,7 @@ export const createClient = ({
 
     const requestInit: MakeRequest['requestInit'] = {
       method: 'DELETE',
+      ...customRequestInit,
     };
 
     await makeRequest({ endpoint, contentId, requestInit });

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -81,7 +81,7 @@ export const createClient = ({
         try {
           const response = await fetchClient(url, {
             ...requestInit,
-            method: requestInit?.method || 'GET',
+            method: requestInit?.method ?? 'GET',
           });
 
           // If a status code in the 400 range other than 429 is returned, do not retry.

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -234,12 +234,12 @@ export const createClient = ({
 
     const queries: MakeRequest['queries'] = isDraft ? { status: 'draft' } : {};
     const requestInit: MakeRequest['requestInit'] = {
+      ...customRequestInit,
       method: contentId ? 'PUT' : 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(content),
-      ...customRequestInit,
     };
 
     return makeRequest({
@@ -264,12 +264,12 @@ export const createClient = ({
     }
 
     const requestInit: MakeRequest['requestInit'] = {
+      ...customRequestInit,
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(content),
-      ...customRequestInit,
     };
 
     return makeRequest({
@@ -296,8 +296,8 @@ export const createClient = ({
     }
 
     const requestInit: MakeRequest['requestInit'] = {
-      method: 'DELETE',
       ...customRequestInit,
+      method: 'DELETE',
     };
 
     await makeRequest({ endpoint, contentId, requestInit });

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -57,9 +57,7 @@ export const createClient = ({
     endpoint,
     contentId,
     queries = {},
-    method,
-    customHeaders,
-    customBody,
+    requestInit,
   }: MakeRequest) => {
     const fetchClient = generateFetchClient(apiKey, customFetch);
     const queryString = parseQuery(queries);
@@ -82,9 +80,8 @@ export const createClient = ({
       async (bail) => {
         try {
           const response = await fetchClient(url, {
-            method: method || 'GET',
-            headers: customHeaders,
-            body: customBody,
+            ...requestInit,
+            method: requestInit?.method || 'GET',
           });
 
           // If a status code in the 400 range other than 429 is returned, do not retry.
@@ -117,7 +114,7 @@ export const createClient = ({
             );
           }
 
-          if (method === 'DELETE') return;
+          if (requestInit?.method === 'DELETE') return;
 
           return response.json();
         } catch (error) {
@@ -220,19 +217,19 @@ export const createClient = ({
     }
 
     const queries: MakeRequest['queries'] = isDraft ? { status: 'draft' } : {};
-    const method: MakeRequest['method'] = contentId ? 'PUT' : 'POST';
-    const customHeaders: MakeRequest['customHeaders'] = {
-      'Content-Type': 'application/json',
+    const requestInit: MakeRequest['requestInit'] = {
+      method: contentId ? 'PUT' : 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(content),
     };
-    const customBody: MakeRequest['customBody'] = JSON.stringify(content);
 
     return makeRequest({
       endpoint,
       contentId,
       queries,
-      method,
-      customHeaders,
-      customBody,
+      requestInit,
     });
   };
 
@@ -248,18 +245,18 @@ export const createClient = ({
       return Promise.reject(new Error('endpoint is required'));
     }
 
-    const method: MakeRequest['method'] = 'PATCH';
-    const customHeaders: MakeRequest['customHeaders'] = {
-      'Content-Type': 'application/json',
+    const requestInit: MakeRequest['requestInit'] = {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(content),
     };
-    const customBody: MakeRequest['customBody'] = JSON.stringify(content);
 
     return makeRequest({
       endpoint,
       contentId,
-      method,
-      customHeaders,
-      customBody,
+      requestInit,
     });
   };
 
@@ -278,9 +275,11 @@ export const createClient = ({
       return Promise.reject(new Error('contentId is required'));
     }
 
-    const method: MakeRequest['method'] = 'DELETE';
+    const requestInit: MakeRequest['requestInit'] = {
+      method: 'DELETE',
+    };
 
-    await makeRequest({ endpoint, contentId, method });
+    await makeRequest({ endpoint, contentId, requestInit });
   };
 
   return {

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -298,6 +298,8 @@ export const createClient = ({
     const requestInit: MakeRequest['requestInit'] = {
       ...customRequestInit,
       method: 'DELETE',
+      headers: {},
+      body: undefined,
     };
 
     await makeRequest({ endpoint, contentId, requestInit });

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,26 +93,26 @@ export interface GetRequest {
   endpoint: string;
   contentId?: string;
   queries?: MicroCMSQueries;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface GetListDetailRequest {
   endpoint: string;
   contentId: string;
   queries?: MicroCMSQueries;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface GetListRequest {
   endpoint: string;
   queries?: MicroCMSQueries;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface GetObjectRequest {
   endpoint: string;
   queries?: MicroCMSQueries;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface WriteApiRequestResult {
@@ -124,18 +124,18 @@ export interface CreateRequest<T> {
   contentId?: string;
   content: T;
   isDraft?: boolean;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface UpdateRequest<T> {
   endpoint: string;
   contentId?: string;
   content: Partial<T>;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }
 
 export interface DeleteRequest {
   endpoint: string;
   contentId: string;
-  customRequestInit: CustomRequestInit;
+  customRequestInit?: CustomRequestInit;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,26 +84,35 @@ export interface MakeRequest {
   requestInit?: RequestInit;
 }
 
+export type CustomRequestInit = Omit<
+  RequestInit,
+  'method' | 'headers' | 'body'
+>;
+
 export interface GetRequest {
   endpoint: string;
   contentId?: string;
   queries?: MicroCMSQueries;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface GetListDetailRequest {
   endpoint: string;
   contentId: string;
   queries?: MicroCMSQueries;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface GetListRequest {
   endpoint: string;
   queries?: MicroCMSQueries;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface GetObjectRequest {
   endpoint: string;
   queries?: MicroCMSQueries;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface WriteApiRequestResult {
@@ -115,15 +124,18 @@ export interface CreateRequest<T> {
   contentId?: string;
   content: T;
   isDraft?: boolean;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface UpdateRequest<T> {
   endpoint: string;
   contentId?: string;
   content: Partial<T>;
+  customRequestInit: CustomRequestInit;
 }
 
 export interface DeleteRequest {
   endpoint: string;
   contentId: string;
+  customRequestInit: CustomRequestInit;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,9 +81,7 @@ export interface MakeRequest {
   endpoint: string;
   contentId?: string;
   queries?: MicroCMSQueries & Record<string, any>;
-  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-  customHeaders?: HeadersInit;
-  customBody?: string;
+  requestInit?: RequestInit;
 }
 
 export interface GetRequest {

--- a/tests/requestInit.test.ts
+++ b/tests/requestInit.test.ts
@@ -1,0 +1,155 @@
+import { createClient } from '../src/createClient';
+import { resolveHeadersConstructor } from '../src/lib/fetch';
+
+const fetchMock = jest.fn(() =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(),
+  })
+);
+
+const client = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'apiKey',
+  customFetch: fetchMock as any,
+});
+
+const Headers = resolveHeadersConstructor();
+
+beforeEach(() => {
+  fetchMock.mockClear();
+});
+
+describe('requestInit', () => {
+  test('Default request init is passed for fetch in get request.', async () => {
+    await client.get({ endpoint: 'object-type' });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'GET',
+      headers: new Headers({
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+    });
+  });
+
+  test('Custom request init added cache parameter is passed for fetch in get request.', async () => {
+    await client.get({
+      endpoint: 'object-type',
+      customRequestInit: {
+        cache: 'no-store',
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'GET',
+      headers: new Headers({
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+      cache: 'no-store',
+    });
+  });
+
+  test('Custom request init added for Next.js parameter is passed for fetch in get request.', async () => {
+    await client.get({
+      endpoint: 'object-type',
+      customRequestInit: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        next: {
+          revalidate: 10,
+        },
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'GET',
+      headers: new Headers({
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+      next: {
+        revalidate: 10,
+      },
+    });
+  });
+
+  test('Custom request init added method, headers and body parameters is not overwrited for fetch in create request.', async () => {
+    await client.create({
+      endpoint: 'list-type',
+      content: { title: 'title' },
+      customRequestInit: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        method: 'GET',
+        headers: {
+          'X-MICROCMS-API-KEY': 'OverwrittenApiKey',
+        },
+        body: { title: 'Overwritten Title' },
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'POST',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+      body: JSON.stringify({ title: 'title' }),
+    });
+  });
+
+  test('Custom request init added method, headers and body parameters is not overwrited for fetch in update request.', async () => {
+    await client.update({
+      endpoint: 'list-type',
+      content: { title: 'title' },
+      customRequestInit: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        method: 'GET',
+        headers: {
+          'X-MICROCMS-API-KEY': 'OverwrittenApiKey',
+        },
+        body: { title: 'Overwritten Title' },
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'POST',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+      body: JSON.stringify({ title: 'title' }),
+    });
+  });
+
+  test('Custom request init added method, headers and body parameters is not overwrited for fetch in delete request.', async () => {
+    await client.delete({
+      endpoint: 'list-type',
+      content: { title: 'title' },
+      customRequestInit: {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        method: 'GET',
+        headers: {
+          'X-MICROCMS-API-KEY': 'OverwrittenApiKey',
+        },
+        body: { title: 'Overwritten Title' },
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(fetchMock.mock.calls[0][1]).toEqual({
+      method: 'POST',
+      headers: new Headers({
+        'Content-Type': 'application/json',
+        'X-MICROCMS-API-KEY': 'apiKey',
+      }),
+      body: JSON.stringify({ title: 'title' }),
+    });
+  });
+});

--- a/tests/requestInit.test.ts
+++ b/tests/requestInit.test.ts
@@ -118,7 +118,7 @@ describe('requestInit', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(fetchMock.mock.calls[0][1]).toEqual({
-      method: 'POST',
+      method: 'PATCH',
       headers: new Headers({
         'Content-Type': 'application/json',
         'X-MICROCMS-API-KEY': 'apiKey',
@@ -130,7 +130,7 @@ describe('requestInit', () => {
   test('Custom request init added method, headers and body parameters is not overwrited for fetch in delete request.', async () => {
     await client.delete({
       endpoint: 'list-type',
-      content: { title: 'title' },
+      contentId: 'contentId',
       customRequestInit: {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
@@ -138,18 +138,15 @@ describe('requestInit', () => {
         headers: {
           'X-MICROCMS-API-KEY': 'OverwrittenApiKey',
         },
-        body: { title: 'Overwritten Title' },
       },
     });
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(fetchMock.mock.calls[0][1]).toEqual({
-      method: 'POST',
+      method: 'DELETE',
       headers: new Headers({
-        'Content-Type': 'application/json',
         'X-MICROCMS-API-KEY': 'apiKey',
       }),
-      body: JSON.stringify({ title: 'title' }),
     });
   });
 });


### PR DESCRIPTION
## 概要
Next.js v13 の App Router では、`fetch()` の `cache` 、`next.revalidate` オプションを利用して、レスポンスデータのキャッシュ有無・期間を設定できる
https://nextjs.org/docs/app/api-reference/functions/fetch

microcms-js-sdk でも設定できるようにした

https://github.com/microcmsio/microcms-js-sdk/commit/169a3ec9c1c8f16292d42ffca28404f118e98b29: 既存コードの `requestInit` 部分を統合
https://github.com/microcmsio/microcms-js-sdk/commit/57b1161aad50f7e243c577ad07ccf4f4561c9b3e: `get` `getList` `update` 等、すべてのメソッドで `requestInit` をカスタマイズできるように