### PR TITLE
Added description of abort controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,25 @@ const response = await client.getList({
 });
 ```
 
+### AbortController: abort() method
+
+You can abort fetch requests.
+
+```ts
+const controller = new AbortController()
+const response = await client.getObject({
+  customRequestInit: {
+    signal: controller.signal
+  },
+  endpoint: "config",
+});
+
+setTimeout(() => {
+  controller.abort()
+}, 1000)
+```
+
+
 # LICENSE
 
 Apache-2.0

--- a/README.md
+++ b/README.md
@@ -279,20 +279,7 @@ client.update<Content>({
 })
 ```
 
-## Tips
-
-### Separate API keys for read and write
-
-```javascript
-const readClient = createClient({
-  serviceDomain: 'serviceDomain',
-  apiKey: 'readApiKey',
-})
-const writeClient = createClient({
-  serviceDomain: 'serviceDomain',
-  apiKey: 'writeApiKey',
-})
-```
+## CustomRequestInit
 
 ### Next.js App Router
 
@@ -328,6 +315,21 @@ const response = await client.getObject({
 setTimeout(() => {
   controller.abort()
 }, 1000)
+```
+
+## Tips
+
+### Separate API keys for read and write
+
+```javascript
+const readClient = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'readApiKey',
+})
+const writeClient = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'writeApiKey',
+})
 ```
 
 


### PR DESCRIPTION
`CustomRequestInit`が利用できることで`AbortController`も利用することができるようになったため、
READMEに`AbortController`についての使用例を追加しました。

また、あわせて`CustomRequestInit`の段落を新たに作成し入れ替えています。