### PR TITLE
fix: getList Response type description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ type Content = {
 /**
  * // getList response type
  * {
- *  contents: Content; // This is Content type
+ *  contents: Content[]; // This is array type of Content
  *  totalCount: number;
  *  limit: number;
  *  offset: number;


### PR DESCRIPTION
getListのResponse Typeの`contents` カラムが配列で返ることがわかりにくいため記載を変更