### PR TITLE
feat: createClient関数で生成される関数の引数にreadonlyを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "async-retry": "^1.3.3",
         "cross-fetch": "^3.1.5",
         "encoding": "^0.1.13",
-        "qs": "^6.10.1"
+        "qs": "^6.10.1",
+        "ts-essentials": "^9.3.2"
       },
       "devDependencies": {
         "@rollup/plugin-babel": "^5.3.0",
@@ -9261,6 +9262,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "node_modules/ts-essentials": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.2.tgz",
+      "integrity": "sha512-JxKJzuWqH1MmH4ZFHtJzGEhkfN3QvVR3C3w+4BIoWeoY68UVVoA2Np/Bca9z0IPSErVCWhv439aT0We4Dks8kQ==",
+      "peerDependencies": {
+        "typescript": ">=4.1.0"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "28.0.7",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
@@ -9362,7 +9371,6 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16742,6 +16750,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
+    "ts-essentials": {
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-9.3.2.tgz",
+      "integrity": "sha512-JxKJzuWqH1MmH4ZFHtJzGEhkfN3QvVR3C3w+4BIoWeoY68UVVoA2Np/Bca9z0IPSErVCWhv439aT0We4Dks8kQ==",
+      "requires": {}
+    },
     "ts-jest": {
       "version": "28.0.7",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
@@ -16799,8 +16813,7 @@
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "rollup -c",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",
+    "typecheck": "tsc --noEmit",
     "test": "jest --coverage=false",
     "test:coverage": "jest --coverage=true"
   },
@@ -32,7 +33,8 @@
     "async-retry": "^1.3.3",
     "cross-fetch": "^3.1.5",
     "encoding": "^0.1.13",
-    "qs": "^6.10.1"
+    "qs": "^6.10.1",
+    "ts-essentials": "^9.3.2"
   },
   "devDependencies": {
     "@rollup/plugin-babel": "^5.3.0",

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -27,6 +27,7 @@ import {
 } from './utils/constants';
 import { generateFetchClient } from './lib/fetch';
 import retry from 'async-retry';
+import { DeepOmit, DeepReadonly } from 'ts-essentials';
 
 /**
  * Initialize SDK Client
@@ -36,7 +37,7 @@ export const createClient = ({
   apiKey,
   customFetch,
   retry: retryOption,
-}: MicroCMSClient) => {
+}: DeepReadonly<MicroCMSClient>) => {
   if (!serviceDomain || !apiKey) {
     throw new Error('parameter is required (check serviceDomain and apiKey)');
   }
@@ -58,7 +59,7 @@ export const createClient = ({
     contentId,
     queries = {},
     requestInit,
-  }: MakeRequest) => {
+  }: DeepReadonly<MakeRequest>) => {
     const fetchClient = generateFetchClient(apiKey, customFetch);
     const queryString = parseQuery(queries);
     const url = `${baseUrl}/${endpoint}${contentId ? `/${contentId}` : ''}${
@@ -80,7 +81,7 @@ export const createClient = ({
       async (bail) => {
         try {
           const response = await fetchClient(url, {
-            ...requestInit,
+            ...(requestInit as RequestInit),
             method: requestInit?.method ?? 'GET',
           });
 
@@ -150,7 +151,7 @@ export const createClient = ({
     contentId,
     queries = {},
     customRequestInit,
-  }: GetRequest): Promise<T> => {
+  }: DeepReadonly<GetRequest>): Promise<T> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -169,7 +170,7 @@ export const createClient = ({
     endpoint,
     queries = {},
     customRequestInit,
-  }: GetListRequest): Promise<MicroCMSListResponse<T>> => {
+  }: DeepReadonly<GetListRequest>): Promise<MicroCMSListResponse<T>> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -188,7 +189,7 @@ export const createClient = ({
     contentId,
     queries = {},
     customRequestInit,
-  }: GetListDetailRequest): Promise<T & MicroCMSListContent> => {
+  }: DeepReadonly<GetListDetailRequest>): Promise<T & MicroCMSListContent> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -207,7 +208,7 @@ export const createClient = ({
     endpoint,
     queries = {},
     customRequestInit,
-  }: GetObjectRequest): Promise<T & MicroCMSObjectContent> => {
+  }: DeepReadonly<GetObjectRequest>): Promise<T & MicroCMSObjectContent> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -227,7 +228,7 @@ export const createClient = ({
     content,
     isDraft = false,
     customRequestInit,
-  }: CreateRequest<T>): Promise<WriteApiRequestResult> => {
+  }: DeepReadonly<CreateRequest<T>>): Promise<WriteApiRequestResult> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -258,7 +259,7 @@ export const createClient = ({
     contentId,
     content,
     customRequestInit,
-  }: UpdateRequest<T>): Promise<WriteApiRequestResult> => {
+  }: DeepReadonly<UpdateRequest<T>>): Promise<WriteApiRequestResult> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
@@ -286,7 +287,7 @@ export const createClient = ({
     endpoint,
     contentId,
     customRequestInit,
-  }: DeleteRequest): Promise<void> => {
+  }: DeepReadonly<DeleteRequest>): Promise<void> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }

--- a/src/utils/parseQuery.ts
+++ b/src/utils/parseQuery.ts
@@ -7,8 +7,9 @@
 import qs from 'qs';
 import { isObject } from './isCheckValue';
 import { MicroCMSQueries } from '../types';
+import { DeepReadonly } from 'ts-essentials';
 
-export const parseQuery = (queries: MicroCMSQueries): string => {
+export const parseQuery = (queries: DeepReadonly<MicroCMSQueries>): string => {
   if (!isObject(queries)) {
     throw new Error('queries is not object');
   }


### PR DESCRIPTION
## 背景
`MicroCMSQuery`の`fields`にリテラル型のタプルを渡した時、以下のような型エラーが発生します。

```ts
// 型エラーの発生する最小構成
const client = createClient({ "apiKey": '', serviceDomain: "" })
client.get({ endpoint: '', queries: { fields: ['id'] as const } })
```

```text
Type 'readonly ["id"]' is not assignable to type 'string | string[] | undefined'.
  The type 'readonly ["id"]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.ts(2322)
```

## 解決策
- createClient関数で生成される関数の引数の全てに`readonly`を追加しました
  - 再帰的に`readonly`を追加するため[ts-essentials](https://github.com/ts-essentials/ts-essentials)を導入しました
  - 引数に対して破壊的変更を行う処理が存在しないため、`readonly`を追加しても問題ないと判断しました

## 懸念点
- `typeof client['get']`のように型を再利用しながら、引数に破壊的な変更を行う既存コードが壊れる可能性があります
  ```ts
  const client = createClient({ "apiKey": '', serviceDomain: "" })
  const get: typeof client['get'] = (p) => {
    if(typeof p.queries?.fields === 'object'){
      p.queries.fields.push() // ここで以下の型エラー
    }
  }
  ``` 

  ```
  Property 'push' does not exist on type 'readonly string[]'.ts(2339)
  ```

## 備考
- `makeRequest`関数で`fetchClient`関数に`requestInit`を渡す際、`readonly`のなしの`RequestInit`にキャストしています
  - `generateFetchClient`関数を確認した限り、キャストした部分の破壊的変更は存在しなかったため、このような実装にしています
- フォークしたリポジトリを使用すると背景の型エラーは解決されることを確認しています