### PR TITLE
getAllContents関数のリファクタ

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,7 @@ module.exports = {
   setupFilesAfterEnv: ['./jest.setup.ts'],
   collectCoverageFrom: ['src/**/*.ts', '!src/index.ts', '!src/types.ts'],
   coverageProvider: 'v8',
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,8 @@ export interface GetAllContentRequest {
   endpoint: string;
   queries?: Omit<MicroCMSQueries, 'limit' | 'offset' | 'ids'>;
   customRequestInit?: CustomRequestInit;
+  limit?: number
+  interval?: number
 }
 
 export interface WriteApiRequestResult {

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -1,0 +1,22 @@
+/**
+ * wait for milliseconds
+ * 
+ * @param ms - milliseconds
+ * @returns {Promise<void>}
+ */
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+  
+/**
+ * run promises in parallel
+ * 
+ * @param promises - array of promises
+ * @returns {T[]}
+ */
+export const partialPromiseAll = async <T>(promises: Promise<T>[]) => {
+  const results = promises.reduce(async (acc: Promise<T[]>, promise: Promise<T>) => {
+    const result = await promise;
+    return [...(await acc), result];
+  }, Promise.resolve([]));
+  return results;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "./",  
   "compilerOptions": {
     "target": "es5",
     "module": "es6",
@@ -11,7 +12,10 @@
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,
-    "useUnknownInCatchVariables": false
+    "useUnknownInCatchVariables": false,
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Issueにしようかと思いましたが、説明するよりコードを書いた方が早かったのでPRを作ってしまいました。
感覚的にはIssueのつもりで出しているので、レスポンスが遅かったりしたら
勝手に修正してマージしてしまっても大丈夫です

## 修正内容
- エイリアスパスでインポートできるようにする
- Promise.allとlimitを併用し、getAllContents関数を高速化する
- limitを引数にして利用者が自由に変更できるようにする
コンテンツ容量によっては、100件取得すると`最大レスポンスサイズ：約5MB`に抵触してエラーになるため
- インターバルを引数にして利用者が自由に変更できるようにする
1秒間に60リクエストという、microCMSの制限ギリギリであるため。

## 補足
テストケースを追加する必要がありそうですが、まだ対応できていないです

## help
テストが通らないです。
ざっくりこんなエラーです
<details>

```
  console.warn
    [MSW] Warning: captured a request without a matching request handler:
    
      • GET https://servicedomain.microcms.io/api/v1/getAllContents-list-type
    
    If you still wish to intercept this unhandled request, please create a request handler for it.
    Read more: https://mswjs.io/docs/getting-started/mocks

      at Object.warn (node_modules/msw/src/utils/internal/devUtils.ts:17:11)
      at applyStrategy (node_modules/msw/src/utils/request/onUnhandledRequest.ts:208:18)
      at onUnhandledRequest (node_modules/msw/src/utils/request/onUnhandledRequest.ts:233:3)
      at handleRequest (node_modules/msw/src/utils/handleRequest.ts:80:5)
      at node_modules/msw/src/node/SetupServerApi.ts:69:24

  console.warn
    [MSW] Warning: captured a request without a matching request handler:
    
      • GET https://servicedomain.microcms.io/api/v1/getAllContents-list-type
    
    If you still wish to intercept this unhandled request, please create a request handler for it.
    Read more: https://mswjs.io/docs/getting-started/mocks

      at Object.warn (node_modules/msw/src/utils/internal/devUtils.ts:17:11)
      at applyStrategy (node_modules/msw/src/utils/request/onUnhandledRequest.ts:208:18)
      at onUnhandledRequest (node_modules/msw/src/utils/request/onUnhandledRequest.ts:233:3)
      at handleRequest (node_modules/msw/src/utils/handleRequest.ts:80:5)
      at node_modules/msw/src/node/SetupServerApi.ts:69:24

  console.warn
    [MSW] Warning: captured a request without a matching request handler:
    
      • GET https://servicedomain.microcms.io/api/v1/getAllContents-list-type
    
    If you still wish to intercept this unhandled request, please create a request handler for it.
    Read more: https://mswjs.io/docs/getting-started/mocks

      at Object.warn (node_modules/msw/src/utils/internal/devUtils.ts:17:11)
      at applyStrategy (node_modules/msw/src/utils/request/onUnhandledRequest.ts:208:18)
      at onUnhandledRequest (node_modules/msw/src/utils/request/onUnhandledRequest.ts:233:3)
      at handleRequest (node_modules/msw/src/utils/handleRequest.ts:80:5)
      at node_modules/msw/src/node/SetupServerApi.ts:69:24

 FAIL  tests/getAllContents.test.ts (12.566 s)
  getAllContents
    ✕ should fetch all contents (1749 ms)
    ✕ should handle pagination and fetch more than limit (1283 ms)

  ● getAllContents › should fetch all contents

    fetch API response status: 404

       98 |
       99 |             return bail(
    > 100 |               new Error(
          |               ^
      101 |                 `fetch API response status: ${response.status}${
      102 |                   message ? `\n  message is \`${message}\`` : ''
      103 |                 }`,

      at src/createClient.ts:100:15
      at step (src/createClient.ts:44:23)
      at Object.next (src/createClient.ts:25:53)
      at fulfilled (src/createClient.ts:16:58)

  ● getAllContents › should handle pagination and fetch more than limit

    fetch API response status: 404

       98 |
       99 |             return bail(
    > 100 |               new Error(
          |               ^
      101 |                 `fetch API response status: ${response.status}${
      102 |                   message ? `\n  message is \`${message}\`` : ''
      103 |                 }`,

      at src/createClient.ts:100:15
      at step (src/createClient.ts:44:23)
      at Object.next (src/createClient.ts:25:53)
      at fulfilled (src/createClient.ts:16:58)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 total
```
</details>