### PR TITLE
CDN利用に関する注意書きの追記と最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ or
 $ yarn add microcms-js-sdk
 ```
 
-CDN support.
+> [!WARNING]
+> The hosting service (unpkg.com) is not related to microCMS. For production use, we recommend self-hosting on your own server.
 
 ```html
-<script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
+<script src="https://unpkg.com/microcms-js-sdk@3.1.0/dist/umd/microcms-js-sdk.js"></script>
 
 or
 
-<script src="https://unpkg.com/microcms-js-sdk@2.7.0/dist/umd/microcms-js-sdk.js"></script>
+<script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
 ```
 
 ### How to use


### PR DESCRIPTION
- 本番利用にはセルフホスティングを推奨する旨を追記しました
(unpkg.comの障害があったことが影響しています)
- 例示されていたバージョンが古かったので、最新化しました
- latest指定は、破壊的な変更で動作しなくなるリスクがあるため、先頭ではなく、2番目に書くようにしました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the README to include a warning about using external hosting services like unpkg.com for production environments and recommends self-hosting.
	- Updated the CDN script reference to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->