### PR TITLE
ファイルの利用方法の案内の整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Download and unzip `microcms-js-sdk-x.y.z.tgz` from the [releases page](https://
 Please load and use the URL provided by an external provider.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/microcms-js-sdk@3.1.0/dist/umd/microcms-js-sdk.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/microcms-js-sdk@3.1.1/dist/umd/microcms-js-sdk.min.js"></script>
 
 or
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ $ yarn add microcms-js-sdk
 
 #### Browser（Self-hosting）
 
-Download and unzip `microcms-js-sdk-x.y.z.zip` from the [releases page](https://github.com/microcmsio/microcms-js-sdk/releases). Then, host it on any server of your choice and use it.
-The target file is `./dist/umd/microcms-js-sdk.js`.
+Download and unzip `microcms-js-sdk-x.y.z.tgz` from the [releases page](https://github.com/microcmsio/microcms-js-sdk/releases). Then, host it on any server of your choice and use it. The target file is `./dist/umd/microcms-js-sdk.js`.
 
 ```html
 <script src="./microcms-js-sdk.js"></script>
@@ -37,11 +36,11 @@ The target file is `./dist/umd/microcms-js-sdk.js`.
 Please load and use the URL provided by an external provider.
 
 ```html
-<script src="https://unpkg.com/microcms-js-sdk@3.1.0/dist/umd/microcms-js-sdk.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/microcms-js-sdk@3.1.0/dist/umd/microcms-js-sdk.min.js"></script>
 
 or
 
-<script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/microcms-js-sdk/dist/umd/microcms-js-sdk.min.js"></script>
 ```
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@ It helps you to use microCMS from JavaScript and Node.js applications.
 
 ### Install
 
-Install npm package.
+#### Node.js
 
-> [!IMPORTANT]
-> v3.0.0 or later requires Node.js **v18 or higher**.
+Install npm package.
 
 ```bash
 $ npm install microcms-js-sdk
@@ -21,8 +20,21 @@ or
 $ yarn add microcms-js-sdk
 ```
 
-> [!WARNING]
-> The hosting service (unpkg.com) is not related to microCMS. For production use, we recommend self-hosting on your own server.
+> [!IMPORTANT]
+> v3.0.0 or later requires Node.js **v18 or higher**.
+
+#### Browser（Self-hosting）
+
+Download and unzip `microcms-js-sdk-x.y.z.zip` from the [releases page](https://github.com/microcmsio/microcms-js-sdk/releases). Then, host it on any server of your choice and use it.
+The target file is `./dist/umd/microcms-js-sdk.js`.
+
+```html
+<script src="./microcms-js-sdk.js"></script>
+```
+
+#### Browser（CDN）
+
+Please load and use the URL provided by an external provider.
 
 ```html
 <script src="https://unpkg.com/microcms-js-sdk@3.1.0/dist/umd/microcms-js-sdk.js"></script>
@@ -31,6 +43,9 @@ or
 
 <script src="https://unpkg.com/microcms-js-sdk@latest/dist/umd/microcms-js-sdk.js"></script>
 ```
+
+> [!WARNING]
+> The hosting service (unpkg.com) is not related to microCMS. For production use, we recommend self-hosting on your own server.
 
 ### How to use
 


### PR DESCRIPTION
- セルフホスティングの方法を追記しました
- UNPKGの運用状況が不明のため、CDNの利用先をjsDelivrに切り替えました
- npmやCDN利用の場合の表記も整理しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated installation instructions for the `microcms-js-sdk` package, specifying Node.js version requirements.
	- Added options for browser usage through self-hosting or CDN.
	- Included warnings about hosting services and production recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->