### PR TITLE
UNPKGの記載が残っていたため、jsdelivrに置き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or
 ```
 
 > [!WARNING]
-> The hosting service (unpkg.com) is not related to microCMS. For production use, we recommend self-hosting on your own server.
+> The hosting service (cdn.jsdelivr.net) is not related to microCMS. For production use, we recommend self-hosting on your own server.
 
 ### How to use
 


### PR DESCRIPTION
- CDNの利用例を、jsdelivrに切り替えましたが、説明上UNPKGが残っていたため、jsdelivrに置き換えました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the recommended hosting service for self-hosting in production to `cdn.jsdelivr.net`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->