### PR TITLE
feat: コンテンツAPI POSTとPUTで `isClosed` オプションをつけると公開終了ステータスで登録できる

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,43 @@ client
   .catch((err) => console.error(err));
 ```
 
+#### Create closed content
+
+By specifying the `isClosed` property, the content can be registered as archived.
+
+```javascript
+client
+  .create({
+    endpoint: 'endpoint',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+    isClosed: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.error(err));
+```
+
+#### Create closed content with specified ID
+
+By specifying the `contentId` and `isClosed` properties, the content can be registered as archived with a specified ID.
+
+```javascript
+client
+  .create({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+    content: {
+      title: 'title',
+      body: 'body',
+    },
+    isClosed: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.error(err));
+```
+
 ### Update content
 
 The `update` method is used to update a single content specified by its ID.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ client
 
 By specifying the `isClosed` property, the content can be registered as archived.
 
+> **Note:** `isDraft` and `isClosed` are mutually exclusive. Do not pass both as `true`; the SDK rejects that combination at runtime with an error. When using `isClosed: true`, omit `isDraft` or set it to `false` (the default).
+
 ```javascript
 client
   .create({
@@ -364,7 +366,7 @@ client
 
 #### Create closed content with specified ID
 
-By specifying the `contentId` and `isClosed` properties, the content can be registered as archived with a specified ID.
+By specifying the `contentId` and `isClosed` properties, the content can be registered as archived with a specified ID. The same rule applies as above: `isDraft` and `isClosed` cannot both be `true`.
 
 ```javascript
 client

--- a/README_jp.md
+++ b/README_jp.md
@@ -348,6 +348,8 @@ client
 
 `isClosed`プロパティを使用することで、公開終了のステータスでコンテンツを登録できます。
 
+> **注:** `isDraft` と `isClosed` は同時に `true` にできません。両方を `true` で渡すと、SDK はランタイムでエラーとして拒否します。`isClosed: true` を使う場合は、`isDraft` を省略、または `false` を設定してください。
+
 ```javascript
 client
   .create({
@@ -364,7 +366,7 @@ client
 
 #### 指定されたIDかつ公開終了のステータスでコンテンツを登録
 
-`contentId`プロパティと`isClosed`プロパティを使用することで、指定されたIDかつ公開終了のステータスでコンテンツを登録できます。
+`contentId`プロパティと`isClosed`プロパティを使用することで、指定されたIDかつ公開終了のステータスでコンテンツを登録できます。上記と同様、`isDraft` と `isClosed` を同時に `true` にすることはできません。
 
 ```javascript
 client

--- a/README_jp.md
+++ b/README_jp.md
@@ -344,6 +344,43 @@ client
   .catch((err) => console.error(err));
 ```
 
+#### 公開終了のステータスでコンテンツを登録
+
+`isClosed`プロパティを使用することで、公開終了のステータスでコンテンツを登録できます。
+
+```javascript
+client
+  .create({
+    endpoint: 'endpoint',
+    content: {
+      title: 'タイトル',
+      body: '本文',
+    },
+    isClosed: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.error(err));
+```
+
+#### 指定されたIDかつ公開終了のステータスでコンテンツを登録
+
+`contentId`プロパティと`isClosed`プロパティを使用することで、指定されたIDかつ公開終了のステータスでコンテンツを登録できます。
+
+```javascript
+client
+  .create({
+    endpoint: 'endpoint',
+    contentId: 'contentId',
+    content: {
+      title: 'タイトル',
+      body: '本文',
+    },
+    isClosed: true,
+  })
+  .then((res) => console.log(res.id))
+  .catch((err) => console.error(err));
+```
+
 ### コンテンツの編集
 
 `update`メソッドは特定のコンテンツを編集するために使用します。

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -327,13 +327,27 @@ export const createClient = ({
     contentId,
     content,
     isDraft = false,
+    isClosed = false,
     customRequestInit,
   }: CreateRequest<T>): Promise<WriteApiRequestResult> => {
     if (!endpoint) {
       return Promise.reject(new Error('endpoint is required'));
     }
 
-    const queries: MakeRequest['queries'] = isDraft ? { status: 'draft' } : {};
+    // if `isClosed` and `isDraft` are true, return an error
+    if (isClosed && isDraft) {
+      return Promise.reject(
+        new Error('isClosed and isDraft cannot be true at the same time'),
+      );
+    }
+
+    const queries: MakeRequest['queries'] = {};
+    if (isDraft) {
+      queries.status = 'draft';
+    } else if (isClosed) {
+      queries.status = 'closed';
+    }
+
     const requestInit: MakeRequest['requestInit'] = {
       ...customRequestInit,
       method: contentId ? 'PUT' : 'POST',

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,7 @@ export interface CreateRequest<T> {
   contentId?: string;
   content: T;
   isDraft?: boolean;
+  isClosed?: boolean;
   customRequestInit?: CustomRequestInit;
 }
 

--- a/tests/createClient.test.ts
+++ b/tests/createClient.test.ts
@@ -239,4 +239,77 @@ describe('createClient', () => {
       expect(apiCallCount).toBe(1);
     }, 30000);
   });
+
+  describe('create', () => {
+    const client = createClient({
+      serviceDomain: 'serviceDomain',
+      apiKey: 'apiKey',
+    });
+
+    test('Rejects when `isDraft` and `isClosed` are both true', () => {
+      return expect(
+        client.create({
+          endpoint: 'list-type',
+          content: { title: 'test' },
+          isDraft: true,
+          isClosed: true,
+        }),
+      ).rejects.toThrow(
+        new Error('isClosed and isDraft cannot be true at the same time'),
+      );
+    });
+
+    test('Sends `status=draft` when only `isDraft` is true', async () => {
+      let requestUrl = '';
+      server.use(
+        http.post(`${testBaseUrl}/list-type`, ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ id: 'foo' });
+        }),
+      );
+
+      await client.create({
+        endpoint: 'list-type',
+        content: { title: 'test' },
+        isDraft: true,
+      });
+
+      expect(new URL(requestUrl).searchParams.get('status')).toBe('draft');
+    });
+
+    test('Sends `status=closed` when only `isClosed` is true', async () => {
+      let requestUrl = '';
+      server.use(
+        http.post(`${testBaseUrl}/list-type`, ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ id: 'foo' });
+        }),
+      );
+
+      await client.create({
+        endpoint: 'list-type',
+        content: { title: 'test' },
+        isClosed: true,
+      });
+
+      expect(new URL(requestUrl).searchParams.get('status')).toBe('closed');
+    });
+
+    test('Does not send `status` when both `isDraft` and `isClosed` are false', async () => {
+      let requestUrl = '';
+      server.use(
+        http.post(`${testBaseUrl}/list-type`, ({ request }) => {
+          requestUrl = request.url;
+          return HttpResponse.json({ id: 'foo' });
+        }),
+      );
+
+      await client.create({
+        endpoint: 'list-type',
+        content: { title: 'test' },
+      });
+
+      expect(new URL(requestUrl).searchParams.get('status')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
- CreateRequestに `isClosed` オプションを追加
- `isClosed` と `isDraft` が両方とも立っている場合はエラーとする
- ユニットテスト追記


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コンテンツを「公開終了（closed）」状態で登録できるようになりました。指定したIDで公開終了として作成することも可能です。

* **ドキュメント**
  * README（日本語版含む）に公開終了状態での登録例と注意事項を追記しました。

* **テスト**
  * 新しい状態フラグの組み合わせ検証とクエリ挙動をカバーするテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->