### PR TITLE
chore: Add publishConfig to package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,4 +25,4 @@ jobs:
           npm run typecheck
           npm run test
           npm run build
-      - run: npm publish --registry=https://registry.npmjs.org
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
   "dependencies": {
     "async-retry": "^1.3.3"
   },


### PR DESCRIPTION
publishConfig で、公開先レジストリを一元管理できる方が良さそうなので修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * npm 公開時の登録先設定を見直し、既定の設定に従う形に整理しました。
  * 公開時の設定をプロジェクト側で明示するようになり、リリース手順が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->