### PR TITLE
リクエストエラーからステータスコード・URL・原因を参照できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,41 @@ type UploadMediaRequest =
 function uploadMedia(params: UploadMediaRequest): Promise<{ url: string }>;
 ```
 
+## エラーハンドリング
+
+microCMS APIへのリクエストに失敗した場合は、`isMicroCMSRequestError`を使用して、HTTPステータスコード、リクエスト先URL、元のネットワークエラーを参照できます。
+
+```typescript
+import { createClient, isMicroCMSRequestError } from 'microcms-js-sdk';
+
+const client = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'apiKey',
+});
+
+try {
+  await client.getList({ endpoint: 'blog' });
+} catch (error) {
+  if (isMicroCMSRequestError(error)) {
+    console.log(error.status);
+    console.log(error.url);
+    console.log(error.originalError);
+  }
+}
+```
+
+| プロパティ      | HTTPエラー                    | ネットワークエラー          |
+| --------------- | ----------------------------- | --------------------------- |
+| `status`        | HTTPステータスコード          | `undefined`                 |
+| `url`           | リクエスト先URL               | リクエスト先URL             |
+| `originalError` | `undefined`                   | `fetch`が投げた元の値       |
+
+`url`に`draftKey`が含まれる場合、その値は`***`にマスクされます。リクエストヘッダー、リクエストボディ、`Response`オブジェクトはエラーへ追加されません。
+
+`originalError`の内容はNode.js、ブラウザ、Edge Runtimeなどの実行環境によって異なり、SDKとして形式を保証しません。
+
+追加されるプロパティは非列挙です。そのため、既存の`message`、`toString()`、`Object.keys()`、`JSON.stringify()`の結果には影響しません。
+
 ## ヒント
 
 ### 読み取り用と書き込み用で別々のAPIキーを使用する

--- a/README_en.md
+++ b/README_en.md
@@ -711,6 +711,41 @@ type UploadMediaRequest =
 function uploadMedia(params: UploadMediaRequest): Promise<{ url: string }>;
 ```
 
+## Error handling
+
+When a request to the microCMS API fails, use `isMicroCMSRequestError` to access the HTTP status code, request URL, and original network error.
+
+```typescript
+import { createClient, isMicroCMSRequestError } from 'microcms-js-sdk';
+
+const client = createClient({
+  serviceDomain: 'serviceDomain',
+  apiKey: 'apiKey',
+});
+
+try {
+  await client.getList({ endpoint: 'blog' });
+} catch (error) {
+  if (isMicroCMSRequestError(error)) {
+    console.log(error.status);
+    console.log(error.url);
+    console.log(error.originalError);
+  }
+}
+```
+
+| Property        | HTTP error       | Network error                  |
+| --------------- | ---------------- | ------------------------------ |
+| `status`        | HTTP status code | `undefined`                    |
+| `url`           | Request URL      | Request URL                    |
+| `originalError` | `undefined`      | Original value thrown by `fetch` |
+
+If `url` contains a `draftKey`, its value is masked as `***`. Request headers, request bodies, and the `Response` object are not added to the error.
+
+The contents of `originalError` depend on the runtime environment, such as Node.js, browsers, or Edge Runtime, and are not guaranteed by this SDK.
+
+The additional properties are non-enumerable, so they do not affect the existing `message`, `toString()`, `Object.keys()`, or `JSON.stringify()` results.
+
 ## Tips
 
 ### Separate API keys for read and write

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -3,6 +3,7 @@
  * https://github.com/microcmsio/microcms-js-sdk
  */
 import retry from 'async-retry';
+import { createMicroCMSRequestError } from './lib/error';
 import { generateFetchClient } from './lib/fetch';
 import {
   CreateRequest,
@@ -96,10 +97,13 @@ export const createClient = ({
             const message = await getMessageFromResponse(response);
 
             return bail(
-              new Error(
-                `fetch API response status: ${response.status}${
-                  message ? `\n  message is \`${message}\`` : ''
-                }`,
+              createMicroCMSRequestError(
+                new Error(
+                  `fetch API response status: ${response.status}${
+                    message ? `\n  message is \`${message}\`` : ''
+                  }`,
+                ),
+                { status: response.status, url },
               ),
             );
           }
@@ -109,10 +113,13 @@ export const createClient = ({
             const message = await getMessageFromResponse(response);
 
             return Promise.reject(
-              new Error(
-                `fetch API response status: ${response.status}${
-                  message ? `\n  message is \`${message}\`` : ''
-                }`,
+              createMicroCMSRequestError(
+                new Error(
+                  `fetch API response status: ${response.status}${
+                    message ? `\n  message is \`${message}\`` : ''
+                  }`,
+                ),
+                { status: response.status, url },
               ),
             );
           }
@@ -130,7 +137,10 @@ export const createClient = ({
           }
 
           return Promise.reject(
-            new Error(`Network Error.\n  Details: ${error.message ?? ''}`),
+            createMicroCMSRequestError(
+              new Error(`Network Error.\n  Details: ${error.message ?? ''}`),
+              { url, originalError: error },
+            ),
           );
         }
       },

--- a/src/createManagementClient.ts
+++ b/src/createManagementClient.ts
@@ -1,3 +1,4 @@
+import { createMicroCMSRequestError } from './lib/error';
 import { generateFetchClient } from './lib/fetch';
 import { MicroCMSManagementClient, UploadMediaRequest } from './types';
 import {
@@ -72,7 +73,10 @@ export const createManagementClient = ({
       }
 
       return Promise.reject(
-        new Error(`Network Error.\n  Details: ${error.message ?? ''}`),
+        createMicroCMSRequestError(
+          new Error(`Network Error.\n  Details: ${error.message ?? ''}`),
+          { url, originalError: error },
+        ),
       );
     }
 
@@ -81,10 +85,13 @@ export const createManagementClient = ({
       const message = await getMessageFromResponse(response);
 
       return Promise.reject(
-        new Error(
-          `fetch API response status: ${response.status}${
-            message ? `\n  message is \`${message}\`` : ''
-          }`,
+        createMicroCMSRequestError(
+          new Error(
+            `fetch API response status: ${response.status}${
+              message ? `\n  message is \`${message}\`` : ''
+            }`,
+          ),
+          { status: response.status, url },
         ),
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { createClient } from './createClient';
 export { createManagementClient } from './createManagementClient';
+export { isMicroCMSRequestError } from './lib/error';
 export * from './types';

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -14,6 +14,9 @@ export const createMicroCMSRequestError = (
   error: Error,
   { status, url, originalError }: CreateMicroCMSRequestErrorOptions,
 ): MicroCMSRequestError => {
+  // Errorとしての実行時の同一性と既存のログ出力を維持するため、独自クラスは生成せず、
+  // 既存のErrorに追加情報を付与する。独自のErrorクラスは将来のメジャーリリースで再検討できる。
+  // 設計背景: https://github.com/microcmsio/microcms-js-sdk/pull/109
   const microCMSRequestError = error as MicroCMSRequestError;
 
   Object.defineProperties(microCMSRequestError, {

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,56 @@
+import { MicroCMSRequestError } from '../types';
+
+interface CreateMicroCMSRequestErrorOptions {
+  status?: number;
+  url: string;
+  originalError?: unknown;
+}
+
+const maskDraftKey = (url: string): string => {
+  return url.replace(/([?&]draftKey=)[^&#]*/g, '$1***');
+};
+
+export const createMicroCMSRequestError = (
+  error: Error,
+  { status, url, originalError }: CreateMicroCMSRequestErrorOptions,
+): MicroCMSRequestError => {
+  const microCMSRequestError = error as MicroCMSRequestError;
+
+  Object.defineProperties(microCMSRequestError, {
+    status: {
+      value: status,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    },
+    url: {
+      value: maskDraftKey(url),
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    },
+    originalError: {
+      value: originalError,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    },
+  });
+
+  return microCMSRequestError;
+};
+
+export const isMicroCMSRequestError = (
+  error: unknown,
+): error is MicroCMSRequestError => {
+  if (!(error instanceof Error)) return false;
+
+  return (
+    Object.prototype.hasOwnProperty.call(error, 'status') &&
+    (typeof (error as MicroCMSRequestError).status === 'number' ||
+      typeof (error as MicroCMSRequestError).status === 'undefined') &&
+    Object.prototype.hasOwnProperty.call(error, 'url') &&
+    typeof (error as MicroCMSRequestError).url === 'string' &&
+    Object.prototype.hasOwnProperty.call(error, 'originalError')
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,15 @@
 export type Fetch = typeof fetch;
 
 /**
+ * Error returned when a microCMS API request fails.
+ */
+export type MicroCMSRequestError = Error & {
+  status: number | undefined;
+  url: string;
+  originalError: unknown | undefined;
+};
+
+/**
  * microCMS createClient params
  */
 export interface MicroCMSClient {

--- a/tests/createClient.test.ts
+++ b/tests/createClient.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { createClient } from '../src/createClient';
+import { createClient, isMicroCMSRequestError } from '../src';
 import { testBaseUrl } from './mocks/handlers';
 import { server } from './mocks/server';
 
@@ -81,6 +81,30 @@ describe('createClient', () => {
         new Error('fetch API response status: 404'),
       );
     });
+
+    test('Returns structured error details and masks draftKey', async () => {
+      server.use(
+        http.get(`${testBaseUrl}/list-type`, async () => {
+          return new HttpResponse(null, { status: 404 });
+        }),
+      );
+      const client = createClient({
+        serviceDomain: 'serviceDomain',
+        apiKey: 'apiKey',
+      });
+
+      const error = await client
+        .get({
+          endpoint: 'list-type',
+          queries: { draftKey: 'secret', fields: 'id' },
+        })
+        .catch((error) => error);
+
+      expect(isMicroCMSRequestError(error)).toBe(true);
+      expect(error.status).toBe(404);
+      expect(error.url).toBe(`${testBaseUrl}/list-type?draftKey=***&fields=id`);
+      expect(error.originalError).toBeUndefined();
+    });
   });
 
   test('Throws an error in the event of a network error.', () => {
@@ -97,6 +121,53 @@ describe('createClient', () => {
     expect(client.get({ endpoint: 'list-type' })).rejects.toThrow(
       new Error('Network Error.\n  Details: Failed to fetch'),
     );
+  });
+
+  test('Keeps the original error in the event of a network error', async () => {
+    const originalError = new TypeError('fetch failed') as TypeError & {
+      cause: unknown;
+    };
+    originalError.cause = { code: 'ENOTFOUND' };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockRejectedValueOnce(originalError);
+    const client = createClient({
+      serviceDomain: 'serviceDomain',
+      apiKey: 'apiKey',
+    });
+
+    const error = await client
+      .get({ endpoint: 'list-type' })
+      .catch((error) => error);
+
+    fetchMock.mockRestore();
+
+    expect(isMicroCMSRequestError(error)).toBe(true);
+    expect(error.status).toBeUndefined();
+    expect(error.url).toBe(`${testBaseUrl}/list-type`);
+    expect(error.originalError).toBe(originalError);
+  });
+
+  test('Does not convert a response body parsing error', async () => {
+    server.use(
+      http.get(`${testBaseUrl}/list-type`, async () => {
+        return new HttpResponse('invalid json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+    const client = createClient({
+      serviceDomain: 'serviceDomain',
+      apiKey: 'apiKey',
+    });
+
+    const error = await client
+      .get({ endpoint: 'list-type' })
+      .catch((error) => error);
+
+    expect(error.name).toBe('SyntaxError');
+    expect(isMicroCMSRequestError(error)).toBe(false);
   });
 
   describe('Retry option is true', () => {
@@ -118,9 +189,16 @@ describe('createClient', () => {
         }),
       );
 
-      await expect(retryableClient.get({ endpoint: '500' })).rejects.toThrow(
-        new Error('fetch API response status: 500'),
-      );
+      const error = await retryableClient
+        .get({ endpoint: '500' })
+        .catch((error) => error);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('fetch API response status: 500');
+      expect(isMicroCMSRequestError(error)).toBe(true);
+      expect(error.status).toBe(500);
+      expect(error.url).toBe(`${testBaseUrl}/500`);
+      expect(error.originalError).toBeUndefined();
       expect(apiCallCount).toBe(3);
     }, 30000);
 

--- a/tests/lib/error.test.ts
+++ b/tests/lib/error.test.ts
@@ -1,0 +1,99 @@
+import {
+  createMicroCMSRequestError,
+  isMicroCMSRequestError,
+} from '../../src/lib/error';
+
+describe('createMicroCMSRequestError', () => {
+  test('adds structured error details without changing the default Error behavior', () => {
+    const error = createMicroCMSRequestError(
+      new Error('fetch API response status: 404'),
+      {
+        status: 404,
+        url: 'https://example.microcms.io/api/v1/blog/abc',
+      },
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.constructor).toBe(Error);
+    expect(error.name).toBe('Error');
+    expect(error.message).toBe('fetch API response status: 404');
+    expect(error.toString()).toBe('Error: fetch API response status: 404');
+    expect(error.status).toBe(404);
+    expect(error.url).toBe('https://example.microcms.io/api/v1/blog/abc');
+    expect(error.originalError).toBeUndefined();
+  });
+
+  test('adds the error details as non-enumerable properties', () => {
+    const error = createMicroCMSRequestError(new Error('Network Error.'), {
+      url: 'https://example.microcms.io/api/v1/blog',
+      originalError: new TypeError('fetch failed'),
+    });
+
+    expect(Object.keys(error)).toEqual([]);
+    expect(JSON.stringify(error)).toBe('{}');
+    expect(Object.getOwnPropertyDescriptor(error, 'status')?.enumerable).toBe(
+      false,
+    );
+    expect(Object.getOwnPropertyDescriptor(error, 'url')?.enumerable).toBe(
+      false,
+    );
+    expect(
+      Object.getOwnPropertyDescriptor(error, 'originalError')?.enumerable,
+    ).toBe(false);
+  });
+
+  test('masks all draftKey values while preserving the other query parameters', () => {
+    const error = createMicroCMSRequestError(
+      new Error('fetch API response status: 404'),
+      {
+        status: 404,
+        url: 'https://example.microcms.io/api/v1/blog/abc?draftKey=secret&fields=id&draftKey=another',
+      },
+    );
+
+    expect(error.url).toBe(
+      'https://example.microcms.io/api/v1/blog/abc?draftKey=***&fields=id&draftKey=***',
+    );
+  });
+
+  test('keeps the original network error without modification', () => {
+    const originalError = new TypeError('fetch failed') as TypeError & {
+      cause: unknown;
+    };
+    originalError.cause = { code: 'ENOTFOUND' };
+    const error = createMicroCMSRequestError(new Error('Network Error.'), {
+      url: 'https://example.microcms.io/api/v1/blog',
+      originalError,
+    });
+
+    expect(error.status).toBeUndefined();
+    expect(error.originalError).toBe(originalError);
+    expect((error.originalError as typeof originalError).cause).toEqual({
+      code: 'ENOTFOUND',
+    });
+  });
+});
+
+describe('isMicroCMSRequestError', () => {
+  test('returns true for an error created by createMicroCMSRequestError', () => {
+    const error = createMicroCMSRequestError(new Error('Network Error.'), {
+      url: 'https://example.microcms.io/api/v1/blog',
+    });
+
+    expect(isMicroCMSRequestError(error)).toBe(true);
+  });
+
+  test('returns false for a standard Error', () => {
+    expect(isMicroCMSRequestError(new Error('standard error'))).toBe(false);
+  });
+
+  test('returns false for a non-Error value with similar properties', () => {
+    expect(
+      isMicroCMSRequestError({
+        status: 404,
+        url: 'https://example.microcms.io/api/v1/blog',
+        originalError: undefined,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

microCMS APIへのリクエストが失敗した際に、原因調査に必要な情報をエラーオブジェクトから参照できるようにしました。

以下の要望への対応を目的としています。

- HTTPエラーのステータスコードを構造化された値として取得したい
- 複数のAPIリクエストのうち、どのURLへのリクエストが失敗したか特定したい
- Node.jsの`fetch`などが持つ、ネットワークエラーの`cause`やエラーコードを確認したい

関連Issue:

- #51
- #82
- #89

## 変更内容

microCMS APIへのHTTP・ネットワークエラーに、以下のプロパティを追加しました。

| プロパティ | HTTPエラー | ネットワークエラー |
| --- | --- | --- |
| `status` | HTTPステータスコード | `undefined` |
| `url` | リクエスト先URL | リクエスト先URL |
| `originalError` | `undefined` | `fetch`が投げた元の値 |

あわせて、TypeScriptから安全にエラーを判定・参照できるよう、以下を公開しました。

- `MicroCMSRequestError` 型
- `isMicroCMSRequestError` type guard

```typescript
try {
  await client.getList({ endpoint: 'blog' });
} catch (error) {
  if (isMicroCMSRequestError(error)) {
    console.log(error.status);
    console.log(error.url);
    console.log(error.originalError);
  }
}
```

Content APIとManagement APIのmicroCMS APIリクエストに適用しています。

## 後方互換性について

独自のエラーclassは導入せず、従来どおり生成した通常の`Error`へ追加情報を付与しています。

追加プロパティは非列挙としているため、以下の既存挙動を維持します。

- `error instanceof Error`
- `error.constructor === Error`
- `error.name`
- `error.message`
- `error.toString()`
- `console.log(error)`の通常表示
- `Object.keys(error)`
- `{ ...error }`
- `JSON.stringify(error)`

既存のエラーメッセージ形式、リトライ条件・回数・間隔・ログ内容も変更していません。

また、HTTP成功後のJSONパースエラーなど、本変更の対象外となるエラーは従来どおりそのまま返します。

### 将来的な独自 Error class の検討

将来、Error の identity（`constructor` / `name` / `instanceof`）を変更する価値が、メジャーバージョンアップに見合うと判断した場合は、以下のような独自 Error class への移行を検討できます。

```ts
export class MicroCMSRequestError extends Error {
  constructor(
    message: string,
    options: MicroCMSRequestErrorOptions,
  ) {
    super(message);
    // status / url / originalError を保持する
  }
}
```

## セキュリティへの配慮

リクエストURLに`draftKey`が含まれる場合は、その値だけを`***`へマスクします。他のクエリパラメータとURLは保持します。

以下の情報はエラーへ追加しません。

- リクエストヘッダー
- APIキー
- リクエストボディ
- `Response`オブジェクト

`originalError`の形式はNode.js、ブラウザ、Edge Runtimeなどの実行環境によって異なるため、SDKとして具体的な形式は保証しません。

## 確認

- `npm test -- --runInBand`
  - 65件成功
  - 既存の10件はskip
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm run build`
- ダミーAPIキーによる401レスポンスで、`status`、マスク済み`url`、既存の`console.log(error)`表示を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新機能
* APIリクエストエラーに、HTTPステータス、URL、元のエラー情報を追加。
* `isMicroCMSRequestError` でリクエストエラーを判定可能に。
* URL内の `draftKey` は安全のためマスクされます。
* エラー情報は既存のメッセージ表示やシリアライズ結果に影響しません。

## ドキュメント
* HTTPエラーとネットワークエラーの詳細、エラーハンドリング方法をREADMEに追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->