### PR TITLE
chore: bump version to 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "microcms-js-sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "microcms-js-sdk",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-retry": "^1.3.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcms-js-sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "JavaScript SDK Client for microCMS.",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## 概要

microcms-js-sdkのバージョンを3.5.0へ更新します。

## 変更内容

- package.jsonのversionを3.5.0へ更新
- npm iを実行し、package-lock.jsonのversionを同期

## 確認

- npm test -- --runInBand
  - 65件成功
  - 既存の10件はskip
- npm run typecheck
- npm run lint
- npm run format
- npm run build

## リリース手順

マージ後、v3.5.0のGitHub Releaseとタグを作成し、release workflowからnpmへ公開します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * パッケージのバージョンを3.4.0から3.5.0へ更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->