### PR TITLE
READMEにエラーの通常出力を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,13 +726,19 @@ const client = createClient({
 try {
   await client.getList({ endpoint: 'blog' });
 } catch (error) {
+  // エラーメッセージとスタックトレースを出力します
+  console.error(error);
+
   if (isMicroCMSRequestError(error)) {
+    // 必要に応じてリクエストに関する追加情報を参照できます
     console.log(error.status);
     console.log(error.url);
     console.log(error.originalError);
   }
 }
 ```
+
+`console.error(error)`でエラーメッセージとスタックトレースを出力できます。HTTPエラーの場合、メッセージにはHTTPステータスとAPIから返されたエラーメッセージが含まれます。`status`、`url`、`originalError`は、必要に応じて個別に参照できる追加情報です。
 
 | プロパティ      | HTTPエラー                    | ネットワークエラー          |
 | --------------- | ----------------------------- | --------------------------- |

--- a/README_en.md
+++ b/README_en.md
@@ -726,13 +726,19 @@ const client = createClient({
 try {
   await client.getList({ endpoint: 'blog' });
 } catch (error) {
+  // Log the error message and stack trace.
+  console.error(error);
+
   if (isMicroCMSRequestError(error)) {
+    // Access additional request details when needed.
     console.log(error.status);
     console.log(error.url);
     console.log(error.originalError);
   }
 }
 ```
+
+`console.error(error)` logs the error message and stack trace. For HTTP errors, the message includes the HTTP status and the error message returned by the API. `status`, `url`, and `originalError` are additional details that can be accessed individually when needed.
 
 | Property        | HTTP error       | Network error                  |
 | --------------- | ---------------- | ------------------------------ |


### PR DESCRIPTION
## 概要

エラーハンドリングのREADME例に、Error本体の出力方法を追記しました。

## 変更内容

- `console.error(error)`でエラーメッセージとスタックトレースを出力する例を追加
- HTTPエラーのメッセージに、HTTPステータスとAPIから返されたエラーメッセージが含まれることを明記
- `status`、`url`、`originalError`は必要に応じて個別に参照できる追加情報であることを明記
- 英語版READMEにも同じ内容を反映

## 背景

追加プロパティの出力例だけでは、通常のError本体が出力されないように見える可能性があったため、初めてREADMEを読む場合でも通常のエラー出力と追加情報の関係が分かるようにしました。

## 確認

- `npm run format`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * エラーハンドリング例に、エラーメッセージとスタックトレースをコンソールへ出力する方法を追加しました。
  * HTTPエラーのメッセージや、ステータス・URL・元のエラー情報を確認する方法を説明しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->