### PR TITLE
READMEのエラーハンドリング説明を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,9 @@ function uploadMedia(params: UploadMediaRequest): Promise<{ url: string }>;
 
 ## エラーハンドリング
 
-microCMS APIへのリクエストに失敗した場合は、`isMicroCMSRequestError`を使用して、HTTPステータスコード、リクエスト先URL、元のネットワークエラーを参照できます。
+microCMS APIへのリクエストに失敗した場合、エラーは通常の`Error`として扱えます。`console.error(error)`でエラーメッセージとスタックトレースを出力でき、HTTPエラーの場合はHTTPステータスとAPIから返されたエラーメッセージも含まれます。
+
+さらに、`isMicroCMSRequestError`でエラーを判定すると、リクエストに関する追加情報として`status`、`url`、`originalError`を個別に参照できます。
 
 ```typescript
 import { createClient, isMicroCMSRequestError } from 'microcms-js-sdk';
@@ -737,8 +739,6 @@ try {
   }
 }
 ```
-
-`console.error(error)`でエラーメッセージとスタックトレースを出力できます。HTTPエラーの場合、メッセージにはHTTPステータスとAPIから返されたエラーメッセージが含まれます。`status`、`url`、`originalError`は、必要に応じて個別に参照できる追加情報です。
 
 | プロパティ      | HTTPエラー                    | ネットワークエラー          |
 | --------------- | ----------------------------- | --------------------------- |

--- a/README_en.md
+++ b/README_en.md
@@ -713,7 +713,9 @@ function uploadMedia(params: UploadMediaRequest): Promise<{ url: string }>;
 
 ## Error handling
 
-When a request to the microCMS API fails, use `isMicroCMSRequestError` to access the HTTP status code, request URL, and original network error.
+When a request to the microCMS API fails, the error can be handled as a standard `Error`. `console.error(error)` logs the error message and stack trace. For HTTP errors, the output also includes the HTTP status and the error message returned by the API.
+
+Additionally, after narrowing the error with `isMicroCMSRequestError`, you can access `status`, `url`, and `originalError` as structured request details.
 
 ```typescript
 import { createClient, isMicroCMSRequestError } from 'microcms-js-sdk';
@@ -737,8 +739,6 @@ try {
   }
 }
 ```
-
-`console.error(error)` logs the error message and stack trace. For HTTP errors, the message includes the HTTP status and the error message returned by the API. `status`, `url`, and `originalError` are additional details that can be accessed individually when needed.
 
 | Property        | HTTP error       | Network error                  |
 | --------------- | ---------------- | ------------------------------ |


### PR DESCRIPTION
## 概要

READMEのエラーハンドリング冒頭とコード例後の説明を統合しました。

## 変更内容

- エラー本体を通常のErrorとして出力できることを冒頭で説明
- HTTPエラーの通常出力に、HTTPステータスとAPIから返されたエラーメッセージが含まれることを明記
- `status`、`url`、`originalError`を、リクエストに関する構造化された追加情報として説明
- コード例後の重複した説明を削除
- 英語版READMEにも同じ内容を反映

## 背景

#112で追加した説明について、初めてREADMEを読む場合にも通常のエラー出力と追加情報の関係が分かるよう、説明の順序と表現を整理しました。

## 確認

- `git diff --check`
- `npm run format`
